### PR TITLE
Add a null check to `FramedModel#getMinMaxPosition`

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/client/loader/FramedModel.java
+++ b/src/main/java/com/buuz135/functionalstorage/client/loader/FramedModel.java
@@ -229,7 +229,7 @@ public class FramedModel implements IUnbakedGeometry<FramedModel> {
 
         private static List<Integer> getMinMaxPosition(List<Float> positions, Direction side) {
             List<Integer> index = new ArrayList<>();
-            float minMax = side.getAxisDirection() == Direction.AxisDirection.POSITIVE ? Collections.max(positions) : Collections.min(positions);
+            float minMax = side != null && side.getAxisDirection() == Direction.AxisDirection.POSITIVE ? Collections.max(positions) : Collections.min(positions);
             for (int i = 0; i < positions.size(); i++) {
                 if (Math.abs(positions.get(i) - minMax) < 0.1) {
                     index.add(i);


### PR DESCRIPTION
Fixes a crash where some blocks rendering would crash the client when rendering the resulting frame