### PR TITLE
Fix weird normals on items in drawers when looking around

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/client/CompactingDrawerRenderer.java
+++ b/src/main/java/com/buuz135/functionalstorage/client/CompactingDrawerRenderer.java
@@ -1,9 +1,9 @@
 package com.buuz135.functionalstorage.client;
 
+import static com.buuz135.functionalstorage.util.MathUtils.createTransformMatrix;
+
 import com.buuz135.functionalstorage.block.tile.CompactingDrawerTile;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.math.Matrix3f;
-import com.mojang.math.Quaternion;
 import com.mojang.math.Vector3f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelRenderer;
@@ -14,63 +14,58 @@ import net.minecraft.world.item.ItemStack;
 
 public class CompactingDrawerRenderer implements BlockEntityRenderer<CompactingDrawerTile> {
 
-    private static final Matrix3f FAKE_NORMALS;
-
-    static {
-        Vector3f NORMAL = new Vector3f(1, 1, 1);
-        NORMAL.normalize();
-        FAKE_NORMALS = new Matrix3f(new Quaternion(NORMAL, 0, true));
-    }
-
     @Override
     public void render(CompactingDrawerTile tile, float partialTicks, PoseStack matrixStack, MultiBufferSource bufferIn, int combinedLightIn, int combinedOverlayIn) {
         if (Minecraft.getInstance().player != null && !tile.getBlockPos().closerThan(Minecraft.getInstance().player.getOnPos(), FunctionalStorageClientConfig.DRAWER_RENDER_RANGE)){
             return;
         }
         matrixStack.pushPose();
-
+        
         Direction facing = tile.getFacingDirection();
-        matrixStack.mulPose(Vector3f.YP.rotationDegrees(-180));
-        if (facing != Direction.SOUTH) matrixStack.last().normal().load(FAKE_NORMALS);
+        matrixStack.mulPoseMatrix(createTransformMatrix(
+        		Vector3f.ZERO, new Vector3f(0, 180, 0), 1));
+        
         if (facing == Direction.NORTH) {
-            //matrixStack.translate(0, 0, 1.016 / 16D);
-            matrixStack.translate(-1, 0, 0);
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(-1, 0, 0), Vector3f.ZERO, 1));
         }
-        if (facing == Direction.EAST) {
-            matrixStack.translate(-1, 0, -1);
-            matrixStack.mulPose(Vector3f.YP.rotationDegrees(-90));
+        else if (facing == Direction.EAST) {
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(-1, 0, -1), new Vector3f(0, -90, 0), 1));
         }
-        if (facing == Direction.SOUTH) {
-            matrixStack.translate(0, 0,-1);
-            matrixStack.mulPose(Vector3f.YP.rotationDegrees(-180));
+        else if (facing == Direction.SOUTH) {
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(0, 0, -1), new Vector3f(0, 180, 0), 1));
         }
-        if (facing == Direction.WEST) {
-            matrixStack.mulPose(Vector3f.YP.rotationDegrees(90));
+        else if (facing == Direction.WEST) {
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(0, 0, 0), new Vector3f(0, 90, 0), 1));
         }
+        
         matrixStack.translate(0,0,-0.5/16D);
         combinedLightIn = LevelRenderer.getLightColor(tile.getLevel(), tile.getBlockPos().relative(facing));
         DrawerRenderer.renderUpgrades(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, tile);
         ItemStack stack = tile.getHandler().getResultList().get(0).getResult();
         if (!stack.isEmpty()){
             matrixStack.pushPose();
-            matrixStack.translate(0.75, 0.27f,0.0005f);
-            matrixStack.scale(0.5f, 0.5f, 0.5f);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(.75f, .27f, .0005f), Vector3f.ZERO, .5f));
             DrawerRenderer.renderStack(matrixStack,  bufferIn, combinedLightIn, combinedOverlayIn, stack, tile.getHandler().getStackInSlot(0).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }
         stack = tile.getHandler().getResultList().get(1).getResult();
         if (!stack.isEmpty()){
             matrixStack.pushPose();
-            matrixStack.translate(0.25, 0.27f,  0.0005f);
-            matrixStack.scale(0.5f, 0.5f, 0.5f);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(.25f, .27f, .0005f), Vector3f.ZERO, .5f));
             DrawerRenderer.renderStack(matrixStack,  bufferIn, combinedLightIn, combinedOverlayIn, stack, tile.getHandler().getStackInSlot(1).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }
         stack = tile.getHandler().getResultList().get(2).getResult();
         if (!stack.isEmpty()){
             matrixStack.pushPose();
-            matrixStack.translate(0.5, 0.77f, 0.0005f);
-            matrixStack.scale(0.5f, 0.5f, 0.5f);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(.5f, .77f, .0005f), Vector3f.ZERO, .5f));
             DrawerRenderer.renderStack(matrixStack,  bufferIn, combinedLightIn, combinedOverlayIn, stack, tile.getHandler().getStackInSlot(2).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }

--- a/src/main/java/com/buuz135/functionalstorage/client/CompactingDrawerRenderer.java
+++ b/src/main/java/com/buuz135/functionalstorage/client/CompactingDrawerRenderer.java
@@ -49,7 +49,7 @@ public class CompactingDrawerRenderer implements BlockEntityRenderer<CompactingD
         if (!stack.isEmpty()){
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(createTransformMatrix(
-            		new Vector3f(.75f, .27f, .0005f), Vector3f.ZERO, .5f));
+            		new Vector3f(.75f, .27f, .0005f), Vector3f.ZERO, new Vector3f(.5f, .5f, 1.0f)));
             DrawerRenderer.renderStack(matrixStack,  bufferIn, combinedLightIn, combinedOverlayIn, stack, tile.getHandler().getStackInSlot(0).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }
@@ -57,7 +57,7 @@ public class CompactingDrawerRenderer implements BlockEntityRenderer<CompactingD
         if (!stack.isEmpty()){
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(createTransformMatrix(
-            		new Vector3f(.25f, .27f, .0005f), Vector3f.ZERO, .5f));
+            		new Vector3f(.25f, .27f, .0005f), Vector3f.ZERO, new Vector3f(.5f, .5f, 1.0f)));
             DrawerRenderer.renderStack(matrixStack,  bufferIn, combinedLightIn, combinedOverlayIn, stack, tile.getHandler().getStackInSlot(1).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }
@@ -65,7 +65,7 @@ public class CompactingDrawerRenderer implements BlockEntityRenderer<CompactingD
         if (!stack.isEmpty()){
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(createTransformMatrix(
-            		new Vector3f(.5f, .77f, .0005f), Vector3f.ZERO, .5f));
+            		new Vector3f(.5f, .77f, .0005f), Vector3f.ZERO, new Vector3f(.5f, .5f, 1.0f)));
             DrawerRenderer.renderStack(matrixStack,  bufferIn, combinedLightIn, combinedOverlayIn, stack, tile.getHandler().getStackInSlot(2).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }

--- a/src/main/java/com/buuz135/functionalstorage/client/DrawerRenderer.java
+++ b/src/main/java/com/buuz135/functionalstorage/client/DrawerRenderer.java
@@ -7,9 +7,6 @@ import com.buuz135.functionalstorage.inventory.BigInventoryHandler;
 import com.buuz135.functionalstorage.item.ConfigurationToolItem;
 import com.buuz135.functionalstorage.util.NumberUtils;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.math.Matrix3f;
-import com.mojang.math.Matrix4f;
-import com.mojang.math.Quaternion;
 import com.mojang.math.Vector3f;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -23,16 +20,10 @@ import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
+import static com.buuz135.functionalstorage.util.MathUtils.*;
+
 public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
-
-    private static final Matrix3f FAKE_NORMALS;
-
-    static {
-        Vector3f NORMAL = new Vector3f(1, 1, 1);
-        NORMAL.normalize();
-        FAKE_NORMALS = new Matrix3f(new Quaternion(NORMAL, 0, true));
-    }
-
+	
     @Override
     public void render(DrawerTile tile, float partialTicks, PoseStack matrixStack, MultiBufferSource bufferIn, int combinedLightIn, int combinedOverlayIn) {
         if (Minecraft.getInstance().player != null && !tile.getBlockPos().closerThan(Minecraft.getInstance().player.getOnPos(), FunctionalStorageClientConfig.DRAWER_RENDER_RANGE)){
@@ -41,22 +32,24 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         matrixStack.pushPose();
 
         Direction facing = tile.getFacingDirection();
-        matrixStack.mulPose(Vector3f.YP.rotationDegrees(-180));
-        if (facing != Direction.SOUTH) matrixStack.last().normal().load(FAKE_NORMALS);
+        matrixStack.mulPoseMatrix(createTransformMatrix(
+        		Vector3f.ZERO, new Vector3f(0, 180, 0), 1));
+        
         if (facing == Direction.NORTH) {
-            //matrixStack.translate(0, 0, 1.016 / 16D);
-            matrixStack.translate(-1, 0, 0);
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(-1, 0, 0), Vector3f.ZERO, 1));
         }
-        if (facing == Direction.EAST) {
-            matrixStack.translate(-1, 0, -1);
-            matrixStack.mulPose(Vector3f.YP.rotationDegrees(-90));
+        else if (facing == Direction.EAST) {
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(-1, 0, -1), new Vector3f(0, -90, 0), 1));
         }
-        if (facing == Direction.SOUTH) {
-            matrixStack.translate(0, 0,-1);
-            matrixStack.mulPose(Vector3f.YP.rotationDegrees(-180));
+        else if (facing == Direction.SOUTH) {
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(0, 0, -1), new Vector3f(0, 180, 0), 1));
         }
-        if (facing == Direction.WEST) {
-            matrixStack.mulPose(Vector3f.YP.rotationDegrees(90));
+        else if (facing == Direction.WEST) {
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(0, 0, 0), new Vector3f(0, 90, 0), 1));
         }
         matrixStack.translate(0,0,-0.5/16D);
         combinedLightIn = LevelRenderer.getLightColor(tile.getLevel(), tile.getBlockPos().relative(facing));
@@ -86,8 +79,8 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         }
         if (tile.isVoid()){
             matrixStack.pushPose();
-            matrixStack.translate(0.969,0.031f,0.469/16D);
-            matrixStack.scale(scale, scale, scale);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(0.969f,0.031f,0.469f/16.0f), Vector3f.ZERO, scale));
             Minecraft.getInstance().getItemRenderer().renderStatic(new ItemStack(FunctionalStorage.VOID_UPGRADE.get()), ItemTransforms.TransformType.NONE, combinedLightIn, combinedOverlayIn, matrixStack, bufferIn, 0);
             matrixStack.popPose();
         }
@@ -106,16 +99,16 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         BigInventoryHandler inventoryHandler = (BigInventoryHandler) tile.getStorage();
         if (!inventoryHandler.getStoredStacks().get(0).getStack().isEmpty()){
             matrixStack.pushPose();
-            matrixStack.translate(0.5, 0.27f, 0.0005f);
-            matrixStack.scale(0.5f, 0.5f, 0.5f);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(0.5f, 0.27f, 0.0005f), Vector3f.ZERO, 0.5f));
             ItemStack stack = inventoryHandler.getStoredStacks().get(0).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(0).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }
         if (!inventoryHandler.getStoredStacks().get(1).getStack().isEmpty()){
             matrixStack.pushPose();
-            matrixStack.translate(0.5, 0.77f, 0.0005f);
-            matrixStack.scale(0.5f, 0.5f, 0.5f);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(0.5f, 0.77f, 0.0005f), Vector3f.ZERO, 0.5f));
             ItemStack stack = inventoryHandler.getStoredStacks().get(1).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(1).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
@@ -125,32 +118,32 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         BigInventoryHandler inventoryHandler = (BigInventoryHandler) tile.getStorage();
         if (!inventoryHandler.getStoredStacks().get(0).getStack().isEmpty()){ //BOTTOM RIGHT
             matrixStack.pushPose();
-            matrixStack.translate(0.75, 0.27f, 0.0005f);
-            matrixStack.scale(0.5f, 0.5f, 0.5f);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(.75f, .27f, .0005f), Vector3f.ZERO, .5f));
             ItemStack stack = inventoryHandler.getStoredStacks().get(0).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(0).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }
         if (!inventoryHandler.getStoredStacks().get(1).getStack().isEmpty()){ //BOTTOM LEFT
             matrixStack.pushPose();
-            matrixStack.translate(0.25, 0.27f, 0.0005f);
-            matrixStack.scale(0.5f, 0.5f, 0.5f);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(.25f, .27f, .0005f), Vector3f.ZERO, .5f));
             ItemStack stack = inventoryHandler.getStoredStacks().get(1).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(1).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }
         if (!inventoryHandler.getStoredStacks().get(2).getStack().isEmpty()){ //TOP RIGHT
             matrixStack.pushPose();
-            matrixStack.translate(0.75, 0.77f, 0.0005f);
-            matrixStack.scale(0.5f, 0.5f, 0.5f);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(.75f, .77f, .0005f), Vector3f.ZERO, .5f));
             ItemStack stack = inventoryHandler.getStoredStacks().get(2).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(2).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
         }
         if (!inventoryHandler.getStoredStacks().get(3).getStack().isEmpty()){ //TOP LEFT
             matrixStack.pushPose();
-            matrixStack.translate(0.25, 0.77f, 0.0005f);
-            matrixStack.scale(0.5f, 0.5f, 0.5f);
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(.25f, .77f, .0005f), Vector3f.ZERO, .5f));
             ItemStack stack = inventoryHandler.getStoredStacks().get(3).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(3).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
@@ -162,13 +155,12 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         BakedModel model = Minecraft.getInstance().getItemRenderer().getModel(stack, Minecraft.getInstance().level, null, 0);
         if (model.isGui3d()){
         	float thickness = (float)FunctionalStorageClientConfig.DRAWER_RENDER_THICKNESS;
-        	Matrix4f pose = new Matrix4f();
-        	// Squish display items instead of translating them backwards into drawer
-        	pose = Matrix4f.createScaleMatrix(0.75f, 0.75f, thickness);
         	// Avoid scaling normal matrix by using mulPoseMatrix() instead of scale()
-        	matrixStack.mulPoseMatrix(pose);
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			Vector3f.ZERO, Vector3f.ZERO, new Vector3f(.75f, .75f, thickness)));
         } else {
-            matrixStack.scale(0.4f, 0.4f, 0.4f);
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			Vector3f.ZERO, Vector3f.ZERO, .4f));
         }
         
         matrixStack.mulPose(Vector3f.YP.rotationDegrees(180));
@@ -177,12 +169,14 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         	Minecraft.getInstance().getItemRenderer().renderStatic(stack, ItemTransforms.TransformType.FIXED, combinedLightIn, combinedOverlayIn, matrixStack, bufferIn, 0);  	
         }
         
-        matrixStack.mulPose(Vector3f.YP.rotationDegrees(-180));
+    	matrixStack.mulPoseMatrix(createTransformMatrix(
+    			Vector3f.ZERO, new Vector3f(0, 180, 0), 1));
         if (!model.isGui3d()){
-            matrixStack.scale(0.5f / 0.4f, 0.5f / 0.4f, 1);
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			Vector3f.ZERO, Vector3f.ZERO, new Vector3f(0.5f / 0.4f, 0.5f / 0.4f, 1)));
         } else {
-            float sl = 0.665f;
-            matrixStack.scale(sl, sl, sl);
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			Vector3f.ZERO, Vector3f.ZERO, .665f));
         }
 
 

--- a/src/main/java/com/buuz135/functionalstorage/client/DrawerRenderer.java
+++ b/src/main/java/com/buuz135/functionalstorage/client/DrawerRenderer.java
@@ -100,7 +100,7 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         if (!inventoryHandler.getStoredStacks().get(0).getStack().isEmpty()){
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(createTransformMatrix(
-            		new Vector3f(0.5f, 0.27f, 0.0005f), Vector3f.ZERO, 0.5f));
+            		new Vector3f(0.5f, 0.27f, 0.0005f), Vector3f.ZERO, new Vector3f(.5f, .5f, 1.0f)));
             ItemStack stack = inventoryHandler.getStoredStacks().get(0).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(0).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
@@ -108,7 +108,7 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         if (!inventoryHandler.getStoredStacks().get(1).getStack().isEmpty()){
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(createTransformMatrix(
-            		new Vector3f(0.5f, 0.77f, 0.0005f), Vector3f.ZERO, 0.5f));
+            		new Vector3f(0.5f, 0.77f, 0.0005f), Vector3f.ZERO, new Vector3f(.5f, .5f, 1.0f)));
             ItemStack stack = inventoryHandler.getStoredStacks().get(1).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(1).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
@@ -119,7 +119,7 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         if (!inventoryHandler.getStoredStacks().get(0).getStack().isEmpty()){ //BOTTOM RIGHT
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(createTransformMatrix(
-            		new Vector3f(.75f, .27f, .0005f), Vector3f.ZERO, .5f));
+            		new Vector3f(.75f, .27f, .0005f), Vector3f.ZERO, new Vector3f(.5f, .5f, 1.0f)));
             ItemStack stack = inventoryHandler.getStoredStacks().get(0).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(0).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
@@ -127,7 +127,7 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         if (!inventoryHandler.getStoredStacks().get(1).getStack().isEmpty()){ //BOTTOM LEFT
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(createTransformMatrix(
-            		new Vector3f(.25f, .27f, .0005f), Vector3f.ZERO, .5f));
+            		new Vector3f(.25f, .27f, .0005f), Vector3f.ZERO, new Vector3f(.5f, .5f, 1.0f)));
             ItemStack stack = inventoryHandler.getStoredStacks().get(1).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(1).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
@@ -135,7 +135,7 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         if (!inventoryHandler.getStoredStacks().get(2).getStack().isEmpty()){ //TOP RIGHT
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(createTransformMatrix(
-            		new Vector3f(.75f, .77f, .0005f), Vector3f.ZERO, .5f));
+            		new Vector3f(.75f, .77f, .0005f), Vector3f.ZERO, new Vector3f(.5f, .5f, 1.0f)));
             ItemStack stack = inventoryHandler.getStoredStacks().get(2).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(2).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();
@@ -143,7 +143,7 @@ public class DrawerRenderer implements BlockEntityRenderer<DrawerTile> {
         if (!inventoryHandler.getStoredStacks().get(3).getStack().isEmpty()){ //TOP LEFT
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(createTransformMatrix(
-            		new Vector3f(.25f, .77f, .0005f), Vector3f.ZERO, .5f));
+            		new Vector3f(.25f, .77f, .0005f), Vector3f.ZERO, new Vector3f(.5f, .5f, 1.0f)));
             ItemStack stack = inventoryHandler.getStoredStacks().get(3).getStack();
             renderStack(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, stack, inventoryHandler.getStackInSlot(3).getCount(), 0.02f, tile.getDrawerOptions());
             matrixStack.popPose();

--- a/src/main/java/com/buuz135/functionalstorage/client/EnderDrawerRenderer.java
+++ b/src/main/java/com/buuz135/functionalstorage/client/EnderDrawerRenderer.java
@@ -1,5 +1,7 @@
 package com.buuz135.functionalstorage.client;
 
+import static com.buuz135.functionalstorage.util.MathUtils.createTransformMatrix;
+
 import com.buuz135.functionalstorage.FunctionalStorage;
 import com.buuz135.functionalstorage.block.tile.ControllableDrawerTile;
 import com.buuz135.functionalstorage.block.tile.EnderDrawerTile;
@@ -7,8 +9,6 @@ import com.buuz135.functionalstorage.inventory.EnderInventoryHandler;
 import com.buuz135.functionalstorage.item.ConfigurationToolItem;
 import com.buuz135.functionalstorage.world.EnderSavedData;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.math.Matrix3f;
-import com.mojang.math.Quaternion;
 import com.mojang.math.Vector3f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelRenderer;
@@ -20,39 +20,34 @@ import net.minecraft.world.item.ItemStack;
 
 public class EnderDrawerRenderer implements BlockEntityRenderer<EnderDrawerTile> {
 
-    private static final Matrix3f FAKE_NORMALS;
-
-    static {
-        Vector3f NORMAL = new Vector3f(1, 1, 1);
-        NORMAL.normalize();
-        FAKE_NORMALS = new Matrix3f(new Quaternion(NORMAL, 0, true));
-    }
-
     @Override
     public void render(EnderDrawerTile tile, float partialTicks, PoseStack matrixStack, MultiBufferSource bufferIn, int combinedLightIn, int combinedOverlayIn) {
         if (Minecraft.getInstance().player != null && !tile.getBlockPos().closerThan(Minecraft.getInstance().player.getOnPos(), FunctionalStorageClientConfig.DRAWER_RENDER_RANGE)){
             return;
         }
         matrixStack.pushPose();
-
+        
         Direction facing = tile.getFacingDirection();
-        matrixStack.mulPose(Vector3f.YP.rotationDegrees(-180));
-        if (facing != Direction.SOUTH) matrixStack.last().normal().load(FAKE_NORMALS);
+        matrixStack.mulPoseMatrix(createTransformMatrix(
+        		Vector3f.ZERO, new Vector3f(0, 180, 0), 1));
+        
         if (facing == Direction.NORTH) {
-            //matrixStack.translate(0, 0, 1.016 / 16D);
-            matrixStack.translate(-1, 0, 0);
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(-1, 0, 0), Vector3f.ZERO, 1));
         }
-        if (facing == Direction.EAST) {
-            matrixStack.translate(-1, 0, -1);
-            matrixStack.mulPose(Vector3f.YP.rotationDegrees(-90));
+        else if (facing == Direction.EAST) {
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(-1, 0, -1), new Vector3f(0, -90, 0), 1));
         }
-        if (facing == Direction.SOUTH) {
-            matrixStack.translate(0, 0,-1);
-            matrixStack.mulPose(Vector3f.YP.rotationDegrees(-180));
+        else if (facing == Direction.SOUTH) {
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(0, 0, -1), new Vector3f(0, 180, 0), 1));
         }
-        if (facing == Direction.WEST) {
-            matrixStack.mulPose(Vector3f.YP.rotationDegrees(90));
+        else if (facing == Direction.WEST) {
+        	matrixStack.mulPoseMatrix(createTransformMatrix(
+        			new Vector3f(0, 0, 0), new Vector3f(0, 90, 0), 1));
         }
+        
         matrixStack.translate(0,0,-0.5/16D);
         combinedLightIn = LevelRenderer.getLightColor(tile.getLevel(), tile.getBlockPos().relative(facing));
         renderUpgrades(matrixStack, bufferIn, combinedLightIn, combinedOverlayIn, tile);
@@ -78,9 +73,9 @@ public class EnderDrawerRenderer implements BlockEntityRenderer<EnderDrawerTile>
             matrixStack.popPose();
         }
         if (tile.isVoid()){
-            matrixStack.pushPose();
-            matrixStack.translate(0.969,0.031f,0.469/16D);
-            matrixStack.scale(scale, scale, scale);
+            matrixStack.pushPose();            
+            matrixStack.mulPoseMatrix(createTransformMatrix(
+            		new Vector3f(.969f, .031f, .469f/16.0f), Vector3f.ZERO, scale));
             Minecraft.getInstance().getItemRenderer().renderStatic(new ItemStack(FunctionalStorage.VOID_UPGRADE.get()), ItemTransforms.TransformType.NONE, combinedLightIn, combinedOverlayIn, matrixStack, bufferIn, 0);
             matrixStack.popPose();
         }

--- a/src/main/java/com/buuz135/functionalstorage/util/MathUtils.java
+++ b/src/main/java/com/buuz135/functionalstorage/util/MathUtils.java
@@ -1,0 +1,29 @@
+package com.buuz135.functionalstorage.util;
+
+import com.mojang.math.Matrix4f;
+import com.mojang.math.Quaternion;
+import com.mojang.math.Vector3f;
+
+public class MathUtils
+{
+	public static Matrix4f createTransformMatrix(Vector3f translation, Vector3f eulerDegrees, Vector3f scale) {
+		Quaternion q = Quaternion.fromXYZDegrees(eulerDegrees);
+		return createTransformMatrix(translation, q, scale);
+	}
+	
+	public static Matrix4f createTransformMatrix(Vector3f translation, Vector3f eulerDegrees, float scale) {
+		return createTransformMatrix(translation, eulerDegrees, new Vector3f(scale, scale, scale));
+	}
+	
+	public static Matrix4f createTransformMatrix(Vector3f translation, Quaternion rotation, Vector3f scale) {
+		Matrix4f transform = Matrix4f.createTranslateMatrix(translation.x(), translation.y(), translation.z());
+		transform.multiply(rotation);
+		Matrix4f scaleMat = Matrix4f.createScaleMatrix(scale.x(), scale.y(), scale.z());
+		transform.multiply(scaleMat);
+		return transform;
+	}
+	
+	public static Matrix4f createTransformMatrix(Vector3f translation, Quaternion rotation, float scale) {
+		return createTransformMatrix(translation, rotation, new Vector3f(scale, scale, scale));
+	}
+}


### PR DESCRIPTION
The normals of blocks in drawers in certain drawer orientations were acting a little weird when looking around, they would shade from light to dark incorrectly depending on the viewing angle.

I've fixed this by removing the fake normals and making sure that any time the blocks/items get scaled it happens with mulPoseMatrix to avoid Mojang's code incorrectly scaling the normals, to make this easier I've added a function that builds a transformation matrix from a translation, rotation and scale.

Before fix:

https://user-images.githubusercontent.com/38669186/209816433-d88b6e57-a684-4cea-bfc4-0e839d766aa8.mp4

After fix:

https://user-images.githubusercontent.com/38669186/209816470-631424b5-83ae-4342-b364-0352b922e38a.mp4