### PR TITLE
Fixing redstone outputs for upgrade

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/block/CompactingDrawerBlock.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/CompactingDrawerBlock.java
@@ -247,8 +247,8 @@ public class CompactingDrawerBlock extends RotatableBlock<CompactingDrawerTile> 
                 if (stack.getItem().equals(FunctionalStorage.REDSTONE_UPGRADE.get())) {
                     int redstoneSlot = stack.getOrCreateTag().getInt("Slot");
                     if (redstoneSlot < tile.getStorage().getSlots()) {
-                        var amount = (tile.getStorage().getStackInSlot(redstoneSlot).getCount() / (double) tile.getStorage().getSlotLimit(redstoneSlot)) * 14;
-                        return Mth.floor(amount * 14.0F) + (amount > 0 ? 1 : 0);
+                        int amount = tile.getStorage().getStackInSlot(redstoneSlot).getCount() * 14 / tile.getStorage().getSlotLimit(redstoneSlot);
+                        return amount + (amount > 0 ? 1 : 0);
                     }
                 }
             }

--- a/src/main/java/com/buuz135/functionalstorage/block/DrawerBlock.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/DrawerBlock.java
@@ -358,8 +358,8 @@ public class DrawerBlock extends RotatableBlock<DrawerTile> {
                 if (stack.getItem().equals(FunctionalStorage.REDSTONE_UPGRADE.get())){
                     int redstoneSlot = stack.getOrCreateTag().getInt("Slot");
                     if (redstoneSlot < tile.getStorage().getSlots()) {
-                        var amount = (tile.getStorage().getStackInSlot(redstoneSlot).getCount() / (double) tile.getStorage().getSlotLimit(redstoneSlot)) * 14;
-                        return Mth.floor(amount * 14.0F) + (amount > 0 ? 1 : 0);
+                        int amount = tile.getStorage().getStackInSlot(redstoneSlot).getCount() * 14 / tile.getStorage().getSlotLimit(redstoneSlot);
+                        return amount + (amount > 0 ? 1 : 0);
                     }
                 }
             }

--- a/src/main/java/com/buuz135/functionalstorage/block/EnderDrawerBlock.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/EnderDrawerBlock.java
@@ -235,8 +235,8 @@ public class EnderDrawerBlock extends RotatableBlock<EnderDrawerTile> {
                 if (stack.getItem().equals(FunctionalStorage.REDSTONE_UPGRADE.get())) {
                     int redstoneSlot = stack.getOrCreateTag().getInt("Slot");
                     if (redstoneSlot < tile.getStorage().getSlots()) {
-                        var amount = (tile.getStorage().getStackInSlot(redstoneSlot).getCount() / (double) tile.getStorage().getSlotLimit(redstoneSlot)) * 14;
-                        return Mth.floor(amount * 14.0F) + (amount > 0 ? 1 : 0);
+                        int amount = tile.getStorage().getStackInSlot(redstoneSlot).getCount() * 14 / tile.getStorage().getSlotLimit(redstoneSlot);
+                        return amount + (amount > 0 ? 1 : 0);
                     }
                 }
             }

--- a/src/main/java/com/buuz135/functionalstorage/block/FluidDrawerBlock.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/FluidDrawerBlock.java
@@ -281,7 +281,7 @@ public class FluidDrawerBlock extends RotatableBlock<FluidDrawerTile> {
                 if (stack.getItem().equals(FunctionalStorage.REDSTONE_UPGRADE.get())) {
                     int redstoneSlot = stack.getOrCreateTag().getInt("Slot");
                     if (redstoneSlot < tile.getFluidHandler().getTanks()) {
-                        return (int) ((tile.getFluidHandler().getFluidInTank(redstoneSlot).getAmount() / (double) tile.getFluidHandler().getTankCapacity(redstoneSlot)) * 16);
+                        retirm tile.getFluidHandler().getFluidInTank(redstoneSlot).getAmount() * 15 / tile.getFluidHandler().getTankCapacity(redstoneSlot);
                     }
                 }
             }

--- a/src/main/java/com/buuz135/functionalstorage/block/SimpleCompactingDrawerBlock.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/SimpleCompactingDrawerBlock.java
@@ -228,8 +228,8 @@ public class SimpleCompactingDrawerBlock extends RotatableBlock<SimpleCompacting
                 if (stack.getItem().equals(FunctionalStorage.REDSTONE_UPGRADE.get())) {
                     int redstoneSlot = stack.getOrCreateTag().getInt("Slot");
                     if (redstoneSlot < tile.getStorage().getSlots()) {
-                        var amount = (tile.getStorage().getStackInSlot(redstoneSlot).getCount() / (double) tile.getStorage().getSlotLimit(redstoneSlot)) * 14;
-                        return Mth.floor(amount * 14.0F) + (amount > 0 ? 1 : 0);
+                        int amount = tile.getStorage().getStackInSlot(redstoneSlot).getCount() * 14 / tile.getStorage().getSlotLimit(redstoneSlot);
+                        return amount + (amount > 0 ? 1 : 0);
                     }
                 }
             }


### PR DESCRIPTION
re: #171 
Removes the extra multiplication by 14 in all Redstone upgrade code.