### PR TITLE
Change Texture Directory for the Framed Simple Compacting Drawer to `block`

### DIFF
--- a/src/main/resources/assets/functionalstorage/models/block/framed_simple_compacting_drawer_locked.json
+++ b/src/main/resources/assets/functionalstorage/models/block/framed_simple_compacting_drawer_locked.json
@@ -5,25 +5,25 @@
     "lock": {
       "parent": "functionalstorage:block/lock",
       "textures": {
-        "lock_icon": "functionalstorage:blocks/lock"
+        "lock_icon": "functionalstorage:block/lock"
       }
     },
     "front": {
       "parent": "functionalstorage:block/front",
       "textures": {
-        "front": "functionalstorage:blocks/framed_front_1"
+        "front": "functionalstorage:block/framed_front_1"
       }
     },
     "side": {
       "parent": "functionalstorage:block/side",
       "textures": {
-        "side": "functionalstorage:blocks/framed_side"
+        "side": "functionalstorage:block/framed_side"
       }
     },
     "front_divider": {
       "parent": "functionalstorage:block/divider_2",
       "textures": {
-        "front_divider": "functionalstorage:blocks/framed_side"
+        "front_divider": "functionalstorage:block/framed_side"
       }
     }
   },
@@ -34,7 +34,7 @@
     "side"
   ],
   "textures": {
-    "particle": "functionalstorage:blocks/framed_front_1"
+    "particle": "functionalstorage:block/framed_front_1"
   },
   "display": {
     "thirdperson_righthand": {


### PR DESCRIPTION
Closes #216 

The texture directory was renamed from `blocks` to `block`; however, one file did not receive any changes to account for this. This updates the json to look for the textures in the correct location.