### PR TITLE
Check Fluid Stack Before Setting Amount

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/fluid/BigFluidHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/fluid/BigFluidHandler.java
@@ -179,7 +179,7 @@ public abstract class BigFluidHandler implements IFluidHandler, INBTSerializable
         @Override
         public @NotNull FluidStack getFluidInTank(int tank) {
             FluidStack stack = super.getFluidInTank(tank);
-            if (isDrawerCreative()) stack.setAmount(Integer.MAX_VALUE);
+            if (!stack.isEmpty() && isDrawerCreative()) stack.setAmount(Integer.MAX_VALUE);
             return stack;
         }
 
@@ -209,7 +209,7 @@ public abstract class BigFluidHandler implements IFluidHandler, INBTSerializable
         @Override
         public @NotNull FluidStack getFluid() {
             FluidStack stack = super.getFluid();
-            if (isDrawerCreative()) stack.setAmount(Integer.MAX_VALUE);
+            if (!stack.isEmpty() && isDrawerCreative()) stack.setAmount(Integer.MAX_VALUE);
             return stack;
         }
 


### PR DESCRIPTION
Closes #213 

When applying the creative upgrade, the fluid drawer attempts to set the amount of the fluid to its max value. However, since there isn't an initial check to see whether a fluid is even present, an error is thrown trying to set the data for an empty fluid. This provides an initial check to make sure the fluid isn't empty before setting the max value. Once the fluid is added, it will be set to its creative value equivalent.