### PR TITLE
Prevent Double Removal of Blocks Using Access Timer

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/block/tile/ItemControllableDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/ItemControllableDrawerTile.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 public abstract class ItemControllableDrawerTile<T extends ItemControllableDrawerTile<T>> extends ControllableDrawerTile<T> {
 
     private static HashMap<UUID, Long> INTERACTION_LOGGER = new HashMap<>();
+    private int removeTicks = 0;
 
     public ItemControllableDrawerTile(BasicTileBlock<T> base, BlockEntityType<T> entityType, BlockPos pos, BlockState state) {
         super(base, entityType, pos, state);
@@ -51,6 +52,7 @@ public abstract class ItemControllableDrawerTile<T extends ItemControllableDrawe
     @Override
     public void serverTick(Level level, BlockPos pos, BlockState state, T blockEntity) {
         super.serverTick(level, pos, state, blockEntity);
+        this.removeTicks = Math.max(this.removeTicks - 1, 0);
         if (level.getGameTime() % FunctionalStorageConfig.UPGRADE_TICK == 0) {
             for (int i = 0; i < this.getUtilityUpgrades().getSlots(); i++) {
                 ItemStack stack = this.getUtilityUpgrades().getStackInSlot(i);
@@ -153,7 +155,8 @@ public abstract class ItemControllableDrawerTile<T extends ItemControllableDrawe
     public abstract int getStorageSlotAmount();
 
     public void onClicked(Player playerIn, int slot) {
-        if (isServer() && slot != -1) {
+        if (isServer() && slot != -1 && this.removeTicks == 0) {
+            this.removeTicks = 3;
             HitResult rayTraceResult = RayTraceUtils.rayTraceSimple(this.level, playerIn, 16, 0);
             if (rayTraceResult.getType() == HitResult.Type.BLOCK) {
                 BlockHitResult blockResult = (BlockHitResult) rayTraceResult;


### PR DESCRIPTION
Closes #212 

See the issue for more details about the problem. TL;DR, the addition of the block into the mining hand is causing a double-click to occur. To prevent this, a timer is added to the inventory to prevent an interaction for the next three ticks, or 150ms. Most people shouldn't be spamming the block this fast, so it will usually go unnoticed.

Thanks to @pupnewfster for providing an example to this solution. ~~I wanted to do mixins~~