### PR TITLE
Backport drawer controller VoxelShape cache to 1.18

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/client/ControllerRenderer.java
+++ b/src/main/java/com/buuz135/functionalstorage/client/ControllerRenderer.java
@@ -84,9 +84,10 @@ public class ControllerRenderer implements BlockEntityRenderer<DrawerControllerT
                     return;
                 }
             }
-            VoxelShape shape = Shapes.create(new AABB(tile.getBlockPos()));
-            for (Long connectedDrawer : tile.getConnectedDrawers().getConnectedDrawers()) {
-                shape = Shapes.join(shape, Shapes.create(new AABB(BlockPos.of(connectedDrawer))), BooleanOp.OR);
+            VoxelShape shape = tile.getConnectedDrawers().getCachedVoxelShape();
+            if (shape == null || tile.getLevel().getGameTime() % 400 == 0) {
+                tile.getConnectedDrawers().rebuildShapes();
+                shape = tile.getConnectedDrawers().getCachedVoxelShape();
             }
             //LevelRenderer.renderVoxelShape(matrixStack, bufferIn.getBuffer(TYPE), shape, -tile.getBlockPos().getX(), -tile.getBlockPos().getY(), -tile.getBlockPos().getZ(), 1f, 1f, 1f, 1f);
             List<AABB> list = shape.toAabbs();


### PR DESCRIPTION
I'm playing a 1.18.2 modpack and experiencing terrible lag as #170 and #194. This is fixed in https://github.com/Buuz135/FunctionalStorage/commit/ccaa44083519ab60f69bbaea0a659c3a1c03150b but not for 1.18.2, so I backported it.