### PR TITLE
Fix massive amount of update packet caused by ConnectedDrawers.rebuild

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/block/tile/DrawerControllerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/DrawerControllerTile.java
@@ -255,6 +255,7 @@ public class DrawerControllerTile extends ItemControllableDrawerTile<DrawerContr
         public void rebuild() {
             this.itemHandlers = new ArrayList<>();
             this.fluidHandlers = new ArrayList<>();
+            this.extensions = 0;
             if (level != null && !level.isClientSide()) {
                 for (Long connectedDrawer : this.connectedDrawers) {
                     BlockPos pos = BlockPos.of(connectedDrawer);
@@ -262,6 +263,7 @@ public class DrawerControllerTile extends ItemControllableDrawerTile<DrawerContr
                     if (entity instanceof DrawerControllerTile) continue;
                     if (entity instanceof ControllerExtensionTile) {
                         ++extensions;
+                        continue;
                     }
                     if (entity instanceof ItemControllableDrawerTile<?> itemControllableDrawerTile) {
                         this.itemHandlers.add(itemControllableDrawerTile.getStorage());


### PR DESCRIPTION
Also fixed in 1.19 and 1.20, but not 1.18: https://github.com/Buuz135/FunctionalStorage/commit/efccf7095d29d67b7530973c59582860cd8d0a5f