### PR TITLE
Add config options for storage upgrade multipliers and how much it should be divided by for fluid drawers and controllers, closes #18 closes #262

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
@@ -48,4 +48,14 @@ public class FunctionalStorageConfig {
 
     @ConfigVal(comment = "How much should the range be divided by for any given Storage Upgrade")
     public static int RANGE_DIVISOR = 4;
+
+    public static int getLevelMult(int level){
+        return switch (level){
+            case 1 -> COPPER_MULTIPLIER;
+            case 2 -> GOLD_MULTIPLIER;
+            case 3 -> DIAMOND_MULTIPLIER;
+            case 4 -> NETHERITE_MULTIPLIER;
+            default -> 1;
+        };
+    }
 }

--- a/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
@@ -31,4 +31,21 @@ public class FunctionalStorageConfig {
     @ConfigVal(comment = "How many items the collector upgrade will try to pull")
     public static int UPGRADE_COLLECTOR_ITEMS = 4;
 
+    @ConfigVal(comment = "How much the storage of an item drawer with a Copper Upgrade should be multiplied by")
+    public static int COPPER_MULTIPLIER = 8;
+
+    @ConfigVal(comment = "How much the storage of an item drawer with a Gold Upgrade should be multiplied by")
+    public static int GOLD_MULTIPLIER = 16;
+
+    @ConfigVal(comment = "How much the storage of an item drawer with a Diamond Upgrade should be multiplied by")
+    public static int DIAMOND_MULTIPLIER = 24;
+
+    @ConfigVal(comment = "How much the storage of an item drawer with a Netherite Upgrade should be multiplied by")
+    public static int NETHERITE_MULTIPLIER = 32;
+
+    @ConfigVal(comment = "How much should the fluid storage be divided by for any given Storage Upgrade")
+    public static int FLUID_DIVISOR = 2;
+
+    @ConfigVal(comment = "How much should the range be divided by for any given Storage Upgrade")
+    public static int RANGE_DIVISOR = 4;
 }

--- a/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
@@ -44,9 +44,11 @@ public class FunctionalStorageConfig {
     public static int NETHERITE_MULTIPLIER = 32;
 
     @ConfigVal(comment = "How much should the fluid storage be divided by for any given Storage Upgrade")
+    @ConfigVal.InRangeInt(min = 1)
     public static int FLUID_DIVISOR = 2;
 
     @ConfigVal(comment = "How much should the range be divided by for any given Storage Upgrade")
+    @ConfigVal.InRangeInt(min = 1)
     public static int RANGE_DIVISOR = 4;
 
     public static int getLevelMult(int level){

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/FluidDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/FluidDrawerTile.java
@@ -111,7 +111,7 @@ public class FluidDrawerTile extends ControllableDrawerTile<FluidDrawerTile> {
 
     @Override
     public double getStorageDiv() {
-        return 2;
+        return FunctionalStorageConfig.FLUID_DIVISOR;
     }
 
     @Override

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/StorageControllerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/StorageControllerTile.java
@@ -82,7 +82,7 @@ public abstract class StorageControllerTile<T extends StorageControllerTile<T>> 
 
     @Override
     public double getStorageDiv() {
-        return 4;
+        return FunctionalStorageConfig.RANGE_DIVISOR;
     }
 
     @Override

--- a/src/main/java/com/buuz135/functionalstorage/item/StorageUpgradeItem.java
+++ b/src/main/java/com/buuz135/functionalstorage/item/StorageUpgradeItem.java
@@ -1,5 +1,6 @@
 package com.buuz135.functionalstorage.item;
 
+import com.buuz135.functionalstorage.block.config.FunctionalStorageConfig;
 import com.hrznstudio.titanium.item.BasicItem;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -38,8 +39,8 @@ public class StorageUpgradeItem extends UpgradeItem{
             tooltip.add(Component.translatable("item.utility.downgrade").withStyle(ChatFormatting.GRAY));
         } else {
             tooltip.add(Component.translatable("storageupgrade.desc.item").withStyle(ChatFormatting.GRAY).append(this.storageTier.getStorageMultiplier() + ""));
-            tooltip.add(Component.translatable("storageupgrade.desc.fluid").withStyle(ChatFormatting.GRAY).append(this.storageTier.getStorageMultiplier() / 2 + ""));
-            tooltip.add(Component.translatable("storageupgrade.desc.range", this.storageTier.getStorageMultiplier() / 4 + "").withStyle(ChatFormatting.GRAY));
+            tooltip.add(Component.translatable("storageupgrade.desc.fluid").withStyle(ChatFormatting.GRAY).append(this.storageTier.getStorageMultiplier() / FunctionalStorageConfig.FLUID_DIVISOR + ""));
+            tooltip.add(Component.translatable("storageupgrade.desc.range", this.storageTier.getStorageMultiplier() / FunctionalStorageConfig.RANGE_DIVISOR + "").withStyle(ChatFormatting.GRAY));
         }
     }
 
@@ -60,10 +61,10 @@ public class StorageUpgradeItem extends UpgradeItem{
     }
 
     public static enum StorageTier {
-        COPPER(8, Mth.color(204/255f, 109/255f, 81/255f)),
-        GOLD(16, Mth.color(233/255f, 177/255f, 21/255f)),
-        DIAMOND(24, Mth.color(32/255f, 197/255f, 181/255f)),
-        NETHERITE(32, Mth.color(49, 41, 42)),
+        COPPER(FunctionalStorageConfig.COPPER_MULTIPLIER, Mth.color(204/255f, 109/255f, 81/255f)),
+        GOLD(FunctionalStorageConfig.GOLD_MULTIPLIER, Mth.color(233/255f, 177/255f, 21/255f)),
+        DIAMOND(FunctionalStorageConfig.DIAMOND_MULTIPLIER, Mth.color(32/255f, 197/255f, 181/255f)),
+        NETHERITE(FunctionalStorageConfig.NETHERITE_MULTIPLIER, Mth.color(49, 41, 42)),
         IRON(1, Mth.color(130/255f, 130/255f, 130/255f));
 
         private final int storageMultiplier;

--- a/src/main/java/com/buuz135/functionalstorage/item/StorageUpgradeItem.java
+++ b/src/main/java/com/buuz135/functionalstorage/item/StorageUpgradeItem.java
@@ -25,7 +25,7 @@ public class StorageUpgradeItem extends UpgradeItem{
     }
 
     public int getStorageMultiplier() {
-        return storageTier.storageMultiplier;
+        return FunctionalStorageConfig.getLevelMult(storageTier.getLevel());
     }
 
     public StorageTier getStorageTier() {
@@ -38,9 +38,9 @@ public class StorageUpgradeItem extends UpgradeItem{
         if (storageTier == StorageTier.IRON){
             tooltip.add(Component.translatable("item.utility.downgrade").withStyle(ChatFormatting.GRAY));
         } else {
-            tooltip.add(Component.translatable("storageupgrade.desc.item").withStyle(ChatFormatting.GRAY).append(this.storageTier.getStorageMultiplier() + ""));
-            tooltip.add(Component.translatable("storageupgrade.desc.fluid").withStyle(ChatFormatting.GRAY).append(this.storageTier.getStorageMultiplier() / FunctionalStorageConfig.FLUID_DIVISOR + ""));
-            tooltip.add(Component.translatable("storageupgrade.desc.range", this.storageTier.getStorageMultiplier() / FunctionalStorageConfig.RANGE_DIVISOR + "").withStyle(ChatFormatting.GRAY));
+            tooltip.add(Component.translatable("storageupgrade.desc.item").withStyle(ChatFormatting.GRAY).append(FunctionalStorageConfig.getLevelMult(this.storageTier.getLevel()) + ""));
+            tooltip.add(Component.translatable("storageupgrade.desc.fluid").withStyle(ChatFormatting.GRAY).append(FunctionalStorageConfig.getLevelMult(this.storageTier.getLevel()) / FunctionalStorageConfig.FLUID_DIVISOR + ""));
+            tooltip.add(Component.translatable("storageupgrade.desc.range", FunctionalStorageConfig.getLevelMult(this.storageTier.getLevel()) / FunctionalStorageConfig.RANGE_DIVISOR + "").withStyle(ChatFormatting.GRAY));
         }
     }
 
@@ -61,22 +61,22 @@ public class StorageUpgradeItem extends UpgradeItem{
     }
 
     public static enum StorageTier {
-        COPPER(FunctionalStorageConfig.COPPER_MULTIPLIER, Mth.color(204/255f, 109/255f, 81/255f)),
-        GOLD(FunctionalStorageConfig.GOLD_MULTIPLIER, Mth.color(233/255f, 177/255f, 21/255f)),
-        DIAMOND(FunctionalStorageConfig.DIAMOND_MULTIPLIER, Mth.color(32/255f, 197/255f, 181/255f)),
-        NETHERITE(FunctionalStorageConfig.NETHERITE_MULTIPLIER, Mth.color(49, 41, 42)),
-        IRON(1, Mth.color(130/255f, 130/255f, 130/255f));
+        COPPER(1, Mth.color(204/255f, 109/255f, 81/255f)),
+        GOLD(2, Mth.color(233/255f, 177/255f, 21/255f)),
+        DIAMOND(3, Mth.color(32/255f, 197/255f, 181/255f)),
+        NETHERITE(4, Mth.color(49, 41, 42)),
+        IRON(0, Mth.color(130/255f, 130/255f, 130/255f));
 
-        private final int storageMultiplier;
+        private final int level;
         private final int color;
 
-        StorageTier(int storageMultiplier, int color) {
-            this.storageMultiplier = storageMultiplier;
+        StorageTier(int level, int color) {
+            this.level = level;
             this.color = color;
         }
 
-        public int getStorageMultiplier() {
-            return storageMultiplier;
+        public int getLevel() {
+            return level;
         }
 
         public int getColor() {


### PR DESCRIPTION
Add config options for storage upgrade multipliers and how much it should be divided by for fluid drawers and controllers. changes how they're implemented a little to accommodate this change. changed where the multipliers were originally hardcoded to be what "level" of upgrade it was, then uses a switch to return the configured multipliers 