### PR TITLE
port pull request #285 to 1.19

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
@@ -31,4 +31,28 @@ public class FunctionalStorageConfig {
     @ConfigVal(comment = "How many items the collector upgrade will try to pull")
     public static int UPGRADE_COLLECTOR_ITEMS = 4;
 
+    @ConfigVal(comment = "How much the storage of an item drawer with a Copper Upgrade should be multiplied by")
+    public static int COPPER_MULTIPLIER = 8;
+
+    @ConfigVal(comment = "How much the storage of an item drawer with a Gold Upgrade should be multiplied by")
+    public static int GOLD_MULTIPLIER = 16;
+
+    @ConfigVal(comment = "How much the storage of an item drawer with a Diamond Upgrade should be multiplied by")
+    public static int DIAMOND_MULTIPLIER = 24;
+
+    @ConfigVal(comment = "How much the storage of an item drawer with a Netherite Upgrade should be multiplied by")
+    public static int NETHERITE_MULTIPLIER = 32;
+
+    @ConfigVal(comment = "How much should the fluid storage be divided by for any given Storage Upgrade")
+    public static int FLUID_DIVISOR = 2;
+
+    public static int getLevelMult(int level){
+        return switch (level){
+            case 1 -> COPPER_MULTIPLIER;
+            case 2 -> GOLD_MULTIPLIER;
+            case 3 -> DIAMOND_MULTIPLIER;
+            case 4 -> NETHERITE_MULTIPLIER;
+            default -> 1;
+        };
+    }
 }

--- a/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/config/FunctionalStorageConfig.java
@@ -44,6 +44,7 @@ public class FunctionalStorageConfig {
     public static int NETHERITE_MULTIPLIER = 32;
 
     @ConfigVal(comment = "How much should the fluid storage be divided by for any given Storage Upgrade")
+    @ConfigVal.InRangeInt(min = 1)
     public static int FLUID_DIVISOR = 2;
 
     public static int getLevelMult(int level){

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/FluidDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/FluidDrawerTile.java
@@ -113,7 +113,7 @@ public class FluidDrawerTile extends ControllableDrawerTile<FluidDrawerTile> {
 
     @Override
     public double getStorageDiv() {
-        return 2;
+        return FunctionalStorageConfig.FLUID_DIVISOR;
     }
 
     @Override

--- a/src/main/java/com/buuz135/functionalstorage/item/StorageUpgradeItem.java
+++ b/src/main/java/com/buuz135/functionalstorage/item/StorageUpgradeItem.java
@@ -1,5 +1,6 @@
 package com.buuz135.functionalstorage.item;
 
+import com.buuz135.functionalstorage.block.config.FunctionalStorageConfig;
 import com.hrznstudio.titanium.item.BasicItem;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -24,7 +25,7 @@ public class StorageUpgradeItem extends UpgradeItem{
     }
 
     public int getStorageMultiplier() {
-        return storageTier.storageMultiplier;
+        return FunctionalStorageConfig.getLevelMult(storageTier.getLevel());
     }
 
     public StorageTier getStorageTier() {
@@ -37,8 +38,8 @@ public class StorageUpgradeItem extends UpgradeItem{
         if (storageTier == StorageTier.IRON){
             tooltip.add(Component.translatable("item.utility.downgrade").withStyle(ChatFormatting.GRAY));
         } else {
-            tooltip.add(Component.translatable("storageupgrade.desc.item").withStyle(ChatFormatting.GRAY).append(this.storageTier.getStorageMultiplier() + ""));
-            tooltip.add(Component.translatable("storageupgrade.desc.fluid").withStyle(ChatFormatting.GRAY).append(this.storageTier.getStorageMultiplier() / 2 + ""));
+            tooltip.add(Component.translatable("storageupgrade.desc.item").withStyle(ChatFormatting.GRAY).append(FunctionalStorageConfig.getLevelMult(this.storageTier.getLevel()) + ""));
+            tooltip.add(Component.translatable("storageupgrade.desc.fluid").withStyle(ChatFormatting.GRAY).append(FunctionalStorageConfig.getLevelMult(this.storageTier.getLevel()) / FunctionalStorageConfig.FLUID_DIVISOR + ""));
         }
     }
 
@@ -59,22 +60,22 @@ public class StorageUpgradeItem extends UpgradeItem{
     }
 
     public static enum StorageTier {
-        COPPER(8, Mth.color(204, 109, 81)),
-        GOLD(16, Mth.color(233, 177, 21)),
-        DIAMOND(24, Mth.color(32, 197, 181)),
-        NETHERITE(32, Mth.color(49, 41, 42)),
-        IRON(1, Mth.color(130, 130, 130));
+        COPPER(1, Mth.color(204, 109, 81)),
+        GOLD(2, Mth.color(233, 177, 21)),
+        DIAMOND(3, Mth.color(32, 197, 181)),
+        NETHERITE(4, Mth.color(49, 41, 42)),
+        IRON(0, Mth.color(130, 130, 130));
 
-        private final int storageMultiplier;
+        private final int level;
         private final int color;
 
-        StorageTier(int storageMultiplier, int color) {
-            this.storageMultiplier = storageMultiplier;
+        StorageTier(int level, int color) {
+            this.level = level;
             this.color = color;
         }
 
-        public int getStorageMultiplier() {
-            return storageMultiplier;
+        public int getLevel() {
+            return level;
         }
 
         public int getColor() {


### PR DESCRIPTION
Add config options for storage upgrade multipliers and how much it should be divided by for fluid drawers. changes how they're implemented a little to accommodate this change. changed where the multipliers were originally hardcoded to be what "level" of upgrade it was, then uses a switch to return the configured multipliers