### PR TITLE
Fix descriptions on pushing/pulling/collector/redstone upgrades

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/item/UpgradeItem.java
+++ b/src/main/java/com/buuz135/functionalstorage/item/UpgradeItem.java
@@ -93,19 +93,16 @@ public class UpgradeItem extends BasicItem {
         super.addTooltipDetails(key, stack, tooltip, advanced);
         tooltip.add(Component.translatable("upgrade.type").withStyle(ChatFormatting.YELLOW).append(Component.translatable("upgrade.type." + getType().name().toLowerCase(Locale.ROOT)).withStyle(ChatFormatting.WHITE)));
         Item item = stack.getItem();
-        if (stack.hasTag()) {
-            if (item.equals(FunctionalStorage.PULLING_UPGRADE.get()) || item.equals(FunctionalStorage.PUSHING_UPGRADE.get()) || item.equals(FunctionalStorage.COLLECTOR_UPGRADE.get())) {
-                tooltip.add(Component.translatable("item.utility.direction").withStyle(ChatFormatting.YELLOW).append(Component.translatable(WordUtils.capitalize(getDirection(stack).getName().toLowerCase(Locale.ROOT))).withStyle(ChatFormatting.WHITE)));
-                tooltip.add(Component.literal(""));
-                tooltip.add(Component.translatable("item.utility.direction.desc").withStyle(ChatFormatting.GRAY));
-            }
-            if (item.equals(FunctionalStorage.REDSTONE_UPGRADE.get())) {
-                tooltip.add(Component.translatable("item.utility.slot").withStyle(ChatFormatting.YELLOW).append(Component.literal(stack.getOrCreateTag().getInt("Slot") + "").withStyle(ChatFormatting.WHITE)));
-                tooltip.add(Component.literal(""));
-                tooltip.add(Component.translatable("item.utility.direction.desc").withStyle(ChatFormatting.GRAY));
-            }
+        if (item.equals(FunctionalStorage.PULLING_UPGRADE.get()) || item.equals(FunctionalStorage.PUSHING_UPGRADE.get()) || item.equals(FunctionalStorage.COLLECTOR_UPGRADE.get())) {
+            tooltip.add(Component.translatable("item.utility.direction").withStyle(ChatFormatting.YELLOW).append(Component.translatable(WordUtils.capitalize(getDirection(stack).getName().toLowerCase(Locale.ROOT))).withStyle(ChatFormatting.WHITE)));
+            tooltip.add(Component.literal(""));
+            tooltip.add(Component.translatable("item.utility.direction.desc").withStyle(ChatFormatting.GRAY));
         }
-
+        if (item.equals(FunctionalStorage.REDSTONE_UPGRADE.get())) {
+            tooltip.add(Component.translatable("item.utility.slot").withStyle(ChatFormatting.YELLOW).append(Component.literal(stack.getOrCreateTag().getInt("Slot") + "").withStyle(ChatFormatting.WHITE)));
+            tooltip.add(Component.literal(""));
+            tooltip.add(Component.translatable("item.utility.slot.desc").withStyle(ChatFormatting.GRAY));
+        }
     }
 
     @Override


### PR DESCRIPTION
I removed the hasTag check so that it shows the instructions and direction/slot by default instead of being blank. I also changed the description on the redstone upgrade to use the slot description instead of the direction description.