### PR TITLE
Tidy old logging code

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/FunctionalStorage.java
+++ b/src/main/java/com/buuz135/functionalstorage/FunctionalStorage.java
@@ -43,6 +43,7 @@ import com.hrznstudio.titanium.nbthandler.NBTManager;
 import com.hrznstudio.titanium.network.NetworkHandler;
 import com.hrznstudio.titanium.recipe.serializer.GenericSerializer;
 import com.hrznstudio.titanium.tab.TitaniumTab;
+import com.mojang.logging.LogUtils;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
@@ -94,8 +95,6 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.RegisterEvent;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.awt.Color;
 import java.util.ArrayList;
@@ -118,8 +117,8 @@ public class FunctionalStorage extends ModuleController {
         NETWORK.registerMessage("ender_drawer_sync", EnderDrawerSyncMessage.class);
     }
 
-    // Directly reference a log4j logger.
-    private static final Logger LOGGER = LogManager.getLogger();
+    // Directly reference a Mojang's logger.
+    private static final org.slf4j.Logger LOGGER = LogUtils.getLogger();
 
     public static ConcurrentLinkedQueue<IWoodType> WOOD_TYPES = new ConcurrentLinkedQueue<>();
 
@@ -141,7 +140,6 @@ public class FunctionalStorage extends ModuleController {
     public static BlockWithTile FRAMED_FLUID_DRAWER_1;
     public static BlockWithTile FRAMED_FLUID_DRAWER_2;
     public static BlockWithTile FRAMED_FLUID_DRAWER_4;
-
 
     public static DeferredHolder<Item, Item> LINKING_TOOL;
     public static HashMap<StorageUpgradeItem.StorageTier, DeferredHolder<Item, Item>> STORAGE_UPGRADES = new HashMap<>();
@@ -220,6 +218,7 @@ public class FunctionalStorage extends ModuleController {
         for (DrawerType value : DrawerType.values()) {
             for (IWoodType woodType : WOOD_TYPES) {
                 var name = woodType.getName() + "_" + value.getSlots();
+                LOGGER.debug("Registering drawer {}", name);
                 if (woodType == DrawerWoodType.FRAMED){
                     var pair = getRegistries().registerBlockWithTileItem(name, () -> new FramedDrawerBlock(value), blockRegistryObject -> () ->
                             new DrawerBlock.DrawerItem((DrawerBlock) blockRegistryObject.get(), new Item.Properties(), TAB),TAB);

--- a/src/main/java/com/buuz135/functionalstorage/client/loader/FramedModel.java
+++ b/src/main/java/com/buuz135/functionalstorage/client/loader/FramedModel.java
@@ -42,8 +42,6 @@ import net.neoforged.neoforge.client.model.geometry.IUnbakedGeometry;
 import net.neoforged.neoforge.common.util.ConcatenatedListView;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3f;
@@ -59,20 +57,12 @@ import static com.buuz135.functionalstorage.client.loader.FramedModel.Baked.getQ
  * Using parts of <a href="https://github.com/SleepyTrousers/EnderIO-Rewrite/blob/dev/1.19.x/src/decor/java/com/enderio/decoration/client/model/painted/PaintedBlockModel.java"> Painted Block Model</a> from Ender IO.
  */
 public class FramedModel implements IUnbakedGeometry<FramedModel> {
-    private static final Logger LOGGER = LogManager.getLogger();
-
     private final ImmutableMap<String, BlockModel> children;
     private final ImmutableList<String> itemPasses;
-    private final boolean logWarning;
 
     public FramedModel(ImmutableMap<String, BlockModel> children, ImmutableList<String> itemPasses) {
-        this(children, itemPasses, false);
-    }
-
-    private FramedModel(ImmutableMap<String, BlockModel> children, ImmutableList<String> itemPasses, boolean logWarning) {
         this.children = children;
         this.itemPasses = itemPasses;
-        this.logWarning = logWarning;
     }
 
     @Override
@@ -462,7 +452,7 @@ public class FramedModel implements IUnbakedGeometry<FramedModel> {
                 }
             }
 
-            return new FramedModel(children, ImmutableList.copyOf(itemPasses), logWarning);
+            return new FramedModel(children, ImmutableList.copyOf(itemPasses));
         }
 
         private boolean readChildren(JsonObject jsonObject, String name, JsonDeserializationContext deserializationContext, ImmutableMap.Builder<String, BlockModel> children, List<String> itemPasses, boolean logWarning) {


### PR DESCRIPTION
Remove a logger code that got left behind in the 1.21 port (f6c1db0c864631abee9201ed1b6f307c5874ef25) and switch the module logger to Mojang's official `LogUtils`.