### PR TITLE
Disable uvlock

### DIFF
--- a/src/generated/resources/assets/functionalstorage/blockstates/acacia_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/acacia_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/acacia_1",
-        "uvlock": true
+        "model": "functionalstorage:block/acacia_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/acacia_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/acacia_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/acacia_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/acacia_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/acacia_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/acacia_2",
-        "uvlock": true
+        "model": "functionalstorage:block/acacia_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/acacia_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/acacia_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/acacia_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/acacia_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/acacia_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/acacia_4",
-        "uvlock": true
+        "model": "functionalstorage:block/acacia_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/acacia_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/acacia_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/acacia_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/armory_cabinet.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/armory_cabinet.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/armory_cabinet",
-        "uvlock": true
+        "model": "functionalstorage:block/armory_cabinet"
       },
       "when": {
         "subfacing": "north"
@@ -12,7 +11,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/armory_cabinet",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/armory_cabinet",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/armory_cabinet",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/birch_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/birch_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/birch_1",
-        "uvlock": true
+        "model": "functionalstorage:block/birch_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/birch_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/birch_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/birch_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/birch_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/birch_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/birch_2",
-        "uvlock": true
+        "model": "functionalstorage:block/birch_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/birch_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/birch_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/birch_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/birch_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/birch_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/birch_4",
-        "uvlock": true
+        "model": "functionalstorage:block/birch_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/birch_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/birch_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/birch_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/cherry_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/cherry_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/cherry_1",
-        "uvlock": true
+        "model": "functionalstorage:block/cherry_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/cherry_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/cherry_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/cherry_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/cherry_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/cherry_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/cherry_2",
-        "uvlock": true
+        "model": "functionalstorage:block/cherry_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/cherry_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/cherry_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/cherry_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/cherry_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/cherry_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/cherry_4",
-        "uvlock": true
+        "model": "functionalstorage:block/cherry_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/cherry_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/cherry_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/cherry_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/compacting_drawer.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/compacting_drawer.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/compacting_drawer",
-        "uvlock": true
+        "model": "functionalstorage:block/compacting_drawer"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/compacting_drawer",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/compacting_drawer",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/compacting_drawer",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/compacting_framed_drawer.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/compacting_framed_drawer.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/compacting_framed_drawer",
-        "uvlock": true
+        "model": "functionalstorage:block/compacting_framed_drawer"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/compacting_framed_drawer",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/compacting_framed_drawer",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/compacting_framed_drawer",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/controller_extension.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/controller_extension.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/controller_extension",
-        "uvlock": true
+        "model": "functionalstorage:block/controller_extension"
       },
       "when": {
         "subfacing": "north"
@@ -12,7 +11,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/controller_extension",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/controller_extension",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/controller_extension",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/crimson_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/crimson_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/crimson_1",
-        "uvlock": true
+        "model": "functionalstorage:block/crimson_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/crimson_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/crimson_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/crimson_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/crimson_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/crimson_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/crimson_2",
-        "uvlock": true
+        "model": "functionalstorage:block/crimson_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/crimson_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/crimson_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/crimson_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/crimson_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/crimson_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/crimson_4",
-        "uvlock": true
+        "model": "functionalstorage:block/crimson_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/crimson_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/crimson_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/crimson_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/dark_oak_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/dark_oak_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/dark_oak_1",
-        "uvlock": true
+        "model": "functionalstorage:block/dark_oak_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/dark_oak_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/dark_oak_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/dark_oak_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/dark_oak_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/dark_oak_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/dark_oak_2",
-        "uvlock": true
+        "model": "functionalstorage:block/dark_oak_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/dark_oak_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/dark_oak_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/dark_oak_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/dark_oak_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/dark_oak_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/dark_oak_4",
-        "uvlock": true
+        "model": "functionalstorage:block/dark_oak_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/dark_oak_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/dark_oak_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/dark_oak_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/ender_drawer.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/ender_drawer.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/ender_drawer",
-        "uvlock": true
+        "model": "functionalstorage:block/ender_drawer"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/ender_drawer",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/ender_drawer",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/ender_drawer",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/fluid_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/fluid_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/fluid_1",
-        "uvlock": true
+        "model": "functionalstorage:block/fluid_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/fluid_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/fluid_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/fluid_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/fluid_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/fluid_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/fluid_2",
-        "uvlock": true
+        "model": "functionalstorage:block/fluid_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/fluid_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/fluid_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/fluid_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/fluid_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/fluid_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/fluid_4",
-        "uvlock": true
+        "model": "functionalstorage:block/fluid_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/fluid_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/fluid_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/fluid_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/framed_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/framed_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/framed_1",
-        "uvlock": true
+        "model": "functionalstorage:block/framed_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/framed_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/framed_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/framed_2",
-        "uvlock": true
+        "model": "functionalstorage:block/framed_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/framed_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/framed_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/framed_4",
-        "uvlock": true
+        "model": "functionalstorage:block/framed_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/framed_controller_extension.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/framed_controller_extension.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/framed_controller_extension",
-        "uvlock": true
+        "model": "functionalstorage:block/framed_controller_extension"
       },
       "when": {
         "subfacing": "north"
@@ -12,7 +11,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_controller_extension",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_controller_extension",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_controller_extension",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/framed_fluid_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/framed_fluid_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/framed_fluid_1",
-        "uvlock": true
+        "model": "functionalstorage:block/framed_fluid_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_fluid_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_fluid_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_fluid_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/framed_fluid_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/framed_fluid_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/framed_fluid_2",
-        "uvlock": true
+        "model": "functionalstorage:block/framed_fluid_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_fluid_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_fluid_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_fluid_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/framed_fluid_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/framed_fluid_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/framed_fluid_4",
-        "uvlock": true
+        "model": "functionalstorage:block/framed_fluid_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_fluid_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_fluid_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_fluid_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/framed_simple_compacting_drawer.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/framed_simple_compacting_drawer.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/framed_simple_compacting_drawer",
-        "uvlock": true
+        "model": "functionalstorage:block/framed_simple_compacting_drawer"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_simple_compacting_drawer",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_simple_compacting_drawer",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_simple_compacting_drawer",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/framed_storage_controller.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/framed_storage_controller.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/framed_storage_controller",
-        "uvlock": true
+        "model": "functionalstorage:block/framed_storage_controller"
       },
       "when": {
         "subfacing": "north"
@@ -12,7 +11,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_storage_controller",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_storage_controller",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/framed_storage_controller",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/jungle_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/jungle_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/jungle_1",
-        "uvlock": true
+        "model": "functionalstorage:block/jungle_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/jungle_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/jungle_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/jungle_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/jungle_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/jungle_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/jungle_2",
-        "uvlock": true
+        "model": "functionalstorage:block/jungle_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/jungle_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/jungle_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/jungle_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/jungle_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/jungle_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/jungle_4",
-        "uvlock": true
+        "model": "functionalstorage:block/jungle_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/jungle_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/jungle_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/jungle_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/mangrove_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/mangrove_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/mangrove_1",
-        "uvlock": true
+        "model": "functionalstorage:block/mangrove_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/mangrove_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/mangrove_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/mangrove_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/mangrove_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/mangrove_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/mangrove_2",
-        "uvlock": true
+        "model": "functionalstorage:block/mangrove_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/mangrove_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/mangrove_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/mangrove_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/mangrove_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/mangrove_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/mangrove_4",
-        "uvlock": true
+        "model": "functionalstorage:block/mangrove_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/mangrove_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/mangrove_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/mangrove_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/oak_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/oak_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/oak_1",
-        "uvlock": true
+        "model": "functionalstorage:block/oak_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/oak_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/oak_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/oak_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/oak_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/oak_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/oak_2",
-        "uvlock": true
+        "model": "functionalstorage:block/oak_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/oak_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/oak_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/oak_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/oak_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/oak_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/oak_4",
-        "uvlock": true
+        "model": "functionalstorage:block/oak_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/oak_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/oak_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/oak_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/simple_compacting_drawer.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/simple_compacting_drawer.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/simple_compacting_drawer",
-        "uvlock": true
+        "model": "functionalstorage:block/simple_compacting_drawer"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/simple_compacting_drawer",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/simple_compacting_drawer",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/simple_compacting_drawer",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/spruce_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/spruce_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/spruce_1",
-        "uvlock": true
+        "model": "functionalstorage:block/spruce_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/spruce_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/spruce_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/spruce_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/spruce_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/spruce_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/spruce_2",
-        "uvlock": true
+        "model": "functionalstorage:block/spruce_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/spruce_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/spruce_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/spruce_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/spruce_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/spruce_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/spruce_4",
-        "uvlock": true
+        "model": "functionalstorage:block/spruce_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/spruce_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/spruce_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/spruce_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/storage_controller.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/storage_controller.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/storage_controller",
-        "uvlock": true
+        "model": "functionalstorage:block/storage_controller"
       },
       "when": {
         "subfacing": "north"
@@ -12,7 +11,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/storage_controller",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/storage_controller",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/storage_controller",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/warped_1.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/warped_1.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/warped_1",
-        "uvlock": true
+        "model": "functionalstorage:block/warped_1"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/warped_1",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/warped_1",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/warped_1",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/warped_2.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/warped_2.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/warped_2",
-        "uvlock": true
+        "model": "functionalstorage:block/warped_2"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/warped_2",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/warped_2",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/warped_2",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/generated/resources/assets/functionalstorage/blockstates/warped_4.json
+++ b/src/generated/resources/assets/functionalstorage/blockstates/warped_4.json
@@ -2,8 +2,7 @@
   "multipart": [
     {
       "apply": {
-        "model": "functionalstorage:block/warped_4",
-        "uvlock": true
+        "model": "functionalstorage:block/warped_4"
       },
       "when": {
         "subfacing": "north"
@@ -11,8 +10,7 @@
     },
     {
       "apply": {
-        "model": "functionalstorage:block/lock",
-        "uvlock": true
+        "model": "functionalstorage:block/lock"
       },
       "when": {
         "locked": "true",
@@ -22,7 +20,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/warped_4",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -32,7 +29,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 180
       },
       "when": {
@@ -43,7 +39,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/warped_4",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -53,7 +48,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 270
       },
       "when": {
@@ -64,7 +58,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/warped_4",
-        "uvlock": true,
         "y": 90
       },
       "when": {
@@ -74,7 +67,6 @@
     {
       "apply": {
         "model": "functionalstorage:block/lock",
-        "uvlock": true,
         "y": 90
       },
       "when": {

--- a/src/main/java/com/buuz135/functionalstorage/data/FunctionalStorageBlockstateProvider.java
+++ b/src/main/java/com/buuz135/functionalstorage/data/FunctionalStorageBlockstateProvider.java
@@ -41,11 +41,11 @@ public class FunctionalStorageBlockstateProvider extends BlockStateProvider {
         var builder = getMultipartBuilder(block);
 
         for (Direction direction : RotatableBlock.FACING_HORIZONTAL.getPossibleValues()) {
-            builder.part().modelFile(baseModel).uvLock(true).rotationY((int) direction.getOpposite().toYRot()).addModel()
+            builder.part().modelFile(baseModel).rotationY((int) direction.getOpposite().toYRot()).addModel()
                 .condition(RotatableBlock.FACING_HORIZONTAL, direction).end();
 
             if (block instanceof Drawer) {
-                builder.part().modelFile(lockModel).uvLock(true).rotationY((int) direction.getOpposite().toYRot()).addModel()
+                builder.part().modelFile(lockModel).rotationY((int) direction.getOpposite().toYRot()).addModel()
                     .condition(RotatableBlock.FACING_HORIZONTAL, direction).condition(DrawerBlock.LOCKED, true).end();
             }
         }


### PR DESCRIPTION
Drawers don't follow the "plank" pattern and should be directional. Turning off uvlock in the state accomplishes this, and makes selecting portions of textures in Blockbench work the same as in-game (since u, v offset/rotation won't be locked at the blockstate level).

This effectively means the tops of drawers will no longer match the universal direction of bricks, but will follow directional placement rules like terracotta.

With `uvlock(true)`:
![uvlock true](https://github.com/user-attachments/assets/a848d22e-4541-45ef-aa61-bf26b9101fa7)

With `uvlock` unspecified (defaults to `false`) (this PR):
![uvlock false](https://github.com/user-attachments/assets/ef52cc33-d61d-4d8b-a797-7b88445d385a)

It specifically enables the tidy/speed up I'm pursuing in kylev/FunctionalStorage#3 and the textures used to paint 3D features.