### PR TITLE
Make item movement examine all destination slots [Fixes #388]

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/item/component/MoveItemsBehavior.java
+++ b/src/main/java/com/buuz135/functionalstorage/item/component/MoveItemsBehavior.java
@@ -33,13 +33,14 @@ public record MoveItemsBehavior(boolean drawerIsSource, int itemsPerOperation) i
             for (int sourceSlot = 0; sourceSlot < source.getSlots(); sourceSlot++) {
                 ItemStack pulledStack = source.extractItem(sourceSlot, itemsPerOperation, true);
                 if (pulledStack.isEmpty()) continue;
+
                 for (int destinationSlot = 0; destinationSlot < destination.getSlots(); destinationSlot++) {
                     if (destination.getStackInSlot(destinationSlot).getCount() >= destination.getSlotLimit(destinationSlot))
                         continue;
-                    ItemStack simulated = destination.insertItem(destinationSlot, pulledStack, true);
-                    if (simulated.getCount() <= pulledStack.getCount()) {
-                        destination.insertItem(destinationSlot, source.extractItem(sourceSlot, pulledStack.getCount() - simulated.getCount(), false), false);
-                        return;
+                    ItemStack remainder = destination.insertItem(destinationSlot, pulledStack, true);
+                    if (remainder.getCount() < pulledStack.getCount()) {
+                        destination.insertItem(destinationSlot, source.extractItem(sourceSlot, pulledStack.getCount() - remainder.getCount(), false), false);
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
We need to break the destination search loop, not return from the method, after an insert. And we need to test if the simulated insert took *some* items from the stack; variable renamed to match the [insertItem() semantics](https://nekoyue.github.io/ForgeJavaDocs-NG/javadoc/1.21.x-neoforge/net/neoforged/neoforge/items/IItemHandler.html#insertItem(int,net.minecraft.world.item.ItemStack,boolean)) and clarify the "if something fits" of the following if-block.

Should fix #388 and multi-slot destination bugs elsewhere. 