### PR TITLE
Support fractional factors and base amounts

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/block/tile/CompactingDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/CompactingDrawerTile.java
@@ -39,7 +39,7 @@ public class CompactingDrawerTile extends ItemControllableDrawerTile<CompactingD
             }
 
             @Override
-            public int getMultiplier() {
+            public float getMultiplier() {
                 return getStorageMultiplier();
             }
 
@@ -118,10 +118,10 @@ public class CompactingDrawerTile extends ItemControllableDrawerTile<CompactingD
     }
 
     @Override
-    protected boolean canChangeMultiplier(long newSizeMultiplier) {
+    protected boolean canChangeMultiplier(double newSizeMultiplier) {
         var stack = getStorage().getStackInSlot(2);
         if (stack.isEmpty()) return true;
-        return stack.getCount() <= Math.min(Integer.MAX_VALUE, stack.getMaxStackSize() * newSizeMultiplier);
+        return stack.getCount() <= Math.min(Integer.MAX_VALUE, Math.floor(stack.getMaxStackSize() * newSizeMultiplier));
     }
 
     @NotNull

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/ControllableDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/ControllableDrawerTile.java
@@ -60,7 +60,7 @@ public abstract class ControllableDrawerTile<T extends ControllableDrawerTile<T>
     public final Supplier<DataComponentType<SizeProvider>> sizeUpgradeComponent;
     @Save
     protected int baseSize;
-    private int storageSize;
+    private float storageSize;
 
     public ControllableDrawerTile(BasicTileBlock<T> base, BlockEntityType<T> entityType, BlockPos pos, BlockState state, DrawerProperties props) {
         super(base, entityType, pos, state);
@@ -180,7 +180,7 @@ public abstract class ControllableDrawerTile<T extends ControllableDrawerTile<T>
         this.controllerPos = null;
     }
 
-    public int getStorageMultiplier() {
+    public float getStorageMultiplier() {
         maybeCacheUpgrades();
         return storageSize;
     }
@@ -265,7 +265,7 @@ public abstract class ControllableDrawerTile<T extends ControllableDrawerTile<T>
 
     public void recalculateUpgrades() {
         isCreative = false;
-        storageSize = SizeProvider.calculate(storageUpgrades, sizeUpgradeComponent, baseSize);
+        storageSize = SizeProvider.calculateAsFactor(storageUpgrades, sizeUpgradeComponent, baseSize);
         for (int i = 0; i < storageUpgrades.getSlots(); i++) {
             Item upgrade = storageUpgrades.getStackInSlot(i).getItem();
             if (upgrade.equals(FunctionalStorage.CREATIVE_UPGRADE.get())) {

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/DrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/DrawerTile.java
@@ -38,7 +38,7 @@ public class DrawerTile extends ItemControllableDrawerTile<DrawerTile> {
             }
 
             @Override
-            public int getMultiplier() {
+            public float getMultiplier() {
                 return getStorageMultiplier();
             }
 

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/FluidDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/FluidDrawerTile.java
@@ -64,8 +64,8 @@ public class FluidDrawerTile extends ControllableDrawerTile<FluidDrawerTile> {
         };
     }
 
-    private int getTankCapacity(int storageMultiplier) {
-        return (int) Math.min(Integer.MAX_VALUE, storageMultiplier * 1000L);
+    private int getTankCapacity(double storageMultiplier) {
+        return (int) Math.min(Integer.MAX_VALUE, Math.floor(storageMultiplier * 1000L));
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -197,7 +197,7 @@ public class FluidDrawerTile extends ControllableDrawerTile<FluidDrawerTile> {
                     var replacement = new ItemStack[this.getSlots()];
                     replacement[slot] = stack;
 
-                    var newSize = SizeProvider.calculate(this, FSAttachments.FLUID_STORAGE_MODIFIER, baseSize, replacement);
+                    var newSize = SizeProvider.calculateAsFactor(this, FSAttachments.FLUID_STORAGE_MODIFIER, baseSize, replacement);
                     for (int i = 0; i < getFluidHandler().getTanks(); i++) {
                         var stored = getFluidHandler().getFluidInTank(i);
                         if (stored.getAmount() > Math.min(Integer.MAX_VALUE, getTankCapacity(newSize))) {

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/ItemControllableDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/ItemControllableDrawerTile.java
@@ -115,7 +115,7 @@ public abstract class ItemControllableDrawerTile<T extends ItemControllableDrawe
                     var replacement = new ItemStack[this.getSlots()];
                     replacement[slot] = ItemStack.EMPTY;
 
-                    var newSize = (long) SizeProvider.calculate(this, FSAttachments.ITEM_STORAGE_MODIFIER, baseSize, replacement);
+                    var newSize = (double) SizeProvider.calculateAsFactor(this, FSAttachments.ITEM_STORAGE_MODIFIER, baseSize, replacement);
                     if (!canChangeMultiplier(newSize)) {
                         return ItemStack.EMPTY;
                     }
@@ -131,7 +131,7 @@ public abstract class ItemControllableDrawerTile<T extends ItemControllableDrawe
                     var replacement = new ItemStack[getStorageUpgrades().getSlots()];
                     replacement[integer] = stack;
 
-                    var newSize = (long) SizeProvider.calculate(getStorageUpgrades(), FSAttachments.ITEM_STORAGE_MODIFIER, baseSize, replacement);
+                    var newSize = (double) SizeProvider.calculateAsFactor(getStorageUpgrades(), FSAttachments.ITEM_STORAGE_MODIFIER, baseSize, replacement);
                     if (!canChangeMultiplier(newSize)) {
                         return false;
                     }
@@ -144,10 +144,10 @@ public abstract class ItemControllableDrawerTile<T extends ItemControllableDrawe
                 .setSlotLimit(1);
     }
 
-    protected boolean canChangeMultiplier(long newSizeMultiplier) {
+    protected boolean canChangeMultiplier(double newSizeMultiplier) {
         for (int i = 0; i < getStorage().getSlots(); i++) {
             var stored = getStorage().getStackInSlot(i);
-            if (!stored.isEmpty() && stored.getCount() > Math.min(Integer.MAX_VALUE, newSizeMultiplier * stored.getMaxStackSize())) {
+            if (!stored.isEmpty() && stored.getCount() > Math.min(Integer.MAX_VALUE, Math.floor(newSizeMultiplier * stored.getMaxStackSize()))) {
                 return false;
             }
         }

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/SimpleCompactingDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/SimpleCompactingDrawerTile.java
@@ -39,7 +39,7 @@ public class SimpleCompactingDrawerTile extends ItemControllableDrawerTile<Simpl
             }
 
             @Override
-            public int getMultiplier() {
+            public float getMultiplier() {
                 return getStorageMultiplier();
             }
 
@@ -119,10 +119,10 @@ public class SimpleCompactingDrawerTile extends ItemControllableDrawerTile<Simpl
     }
 
     @Override
-    protected boolean canChangeMultiplier(long newSizeMultiplier) {
+    protected boolean canChangeMultiplier(double newSizeMultiplier) {
         var stack = getStorage().getStackInSlot(1);
         if (stack.isEmpty()) return true;
-        return stack.getCount() <= Math.min(Integer.MAX_VALUE, stack.getMaxStackSize() * newSizeMultiplier);
+        return stack.getCount() <= Math.min(Integer.MAX_VALUE, Math.floor(stack.getMaxStackSize() * newSizeMultiplier));
     }
 
     @NotNull

--- a/src/main/java/com/buuz135/functionalstorage/inventory/BigInventoryHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/BigInventoryHandler.java
@@ -150,7 +150,7 @@ public abstract class BigInventoryHandler implements IItemHandler, INBTSerializa
 
     public abstract void onChange();
 
-    public abstract int getMultiplier();
+    public abstract float getMultiplier();
 
     public double getTotalAmount() {
         return 64d * getMultiplier();

--- a/src/main/java/com/buuz135/functionalstorage/inventory/CompactingInventoryHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/CompactingInventoryHandler.java
@@ -18,8 +18,6 @@ public abstract class CompactingInventoryHandler implements IItemHandler, INBTSe
     public static final String STACK = "Stack";
     public static final String AMOUNT = "Amount";
 
-    public int totalAmount;
-
     private int amount;
     private ItemStack parent;
     private List<CompactingUtil.Result> resultList;
@@ -206,7 +204,7 @@ public abstract class CompactingInventoryHandler implements IItemHandler, INBTSe
 
     public abstract void onChange();
 
-    public abstract int getMultiplier();
+    public abstract float getMultiplier();
 
     public abstract boolean isVoid();
 

--- a/src/main/java/com/buuz135/functionalstorage/inventory/EnderInventoryHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/EnderInventoryHandler.java
@@ -51,7 +51,7 @@ public class EnderInventoryHandler extends BigInventoryHandler implements ILocka
     }
 
     @Override
-    public int getMultiplier() {
+    public float getMultiplier() {
         return 1;
     }
 

--- a/src/main/java/com/buuz135/functionalstorage/inventory/item/CompactingStackItemHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/item/CompactingStackItemHandler.java
@@ -27,7 +27,7 @@ public class CompactingStackItemHandler implements IItemHandler, INBTSerializabl
     private ItemStack parent;
     private List<CompactingUtil.Result> resultList;
     private final int slots;
-    private int size;
+    private float size;
     private boolean isVoid;
     private boolean isCreative;
     private final ItemStack stack;
@@ -49,7 +49,7 @@ public class CompactingStackItemHandler implements IItemHandler, INBTSerializabl
 
             var upgrades = new ItemStackHandler();
             upgrades.deserializeNBT(Utils.registryAccess(), tile.getCompound("storageUpgrades"));
-            size = SizeProvider.calculate(upgrades, FSAttachments.ITEM_STORAGE_MODIFIER, size);
+            size = SizeProvider.calculateAsFactor(upgrades, FSAttachments.ITEM_STORAGE_MODIFIER, size);
 
             for (Tag tag : tile.getCompound("storageUpgrades").getList("Items", Tag.TAG_COMPOUND)) {
                 ItemStack itemStack = Utils.deserialize(Utils.registryAccess(), (CompoundTag) tag);
@@ -92,7 +92,7 @@ public class CompactingStackItemHandler implements IItemHandler, INBTSerializabl
             int inserted = Math.min(getSlotLimit(slot) * result.getNeeded() - amount, stack.getCount() * result.getNeeded());
             inserted = (int) (Math.floor(inserted / result.getNeeded()) * result.getNeeded());
             if (!simulate) {
-                this.amount = Math.min(this.amount + inserted, size * 64 * 9 * 9);
+                this.amount = Math.min(this.amount + inserted, (int) Math.floor(size * 64 * 9 * 9));
                 onChange();
             }
             if (inserted == stack.getCount() * result.getNeeded() || isVoid()) return ItemStack.EMPTY;

--- a/src/main/java/com/buuz135/functionalstorage/inventory/item/DrawerStackItemHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/item/DrawerStackItemHandler.java
@@ -27,7 +27,7 @@ public class DrawerStackItemHandler implements IItemHandler, INBTSerializable<Co
     private List<BigInventoryHandler.BigStack> storedStacks;
     private ItemStack stack;
     private FunctionalStorage.DrawerType type;
-    private int size;
+    private float size;
     private boolean isVoid;
     private boolean isCreative;
 
@@ -49,7 +49,7 @@ public class DrawerStackItemHandler implements IItemHandler, INBTSerializable<Co
 
             var upgrades = new ItemStackHandler();
             upgrades.deserializeNBT(access, tile.getCompound("storageUpgrades"));
-            size = SizeProvider.calculate(upgrades, FSAttachments.ITEM_STORAGE_MODIFIER, drawerType.getSlotAmount());
+            size = SizeProvider.calculateAsFactor(upgrades, FSAttachments.ITEM_STORAGE_MODIFIER, drawerType.getSlotAmount());
 
             for (Tag tag : tile.getCompound("utilityUpgrades").getList("Items", Tag.TAG_COMPOUND)) {
                 ItemStack itemStack = Utils.deserialize(access, (CompoundTag) tag);
@@ -176,7 +176,7 @@ public class DrawerStackItemHandler implements IItemHandler, INBTSerializable<Co
             maxSize = stored.getMaxStackSize();
         }
 
-        return (int) Math.min(Integer.MAX_VALUE, size * maxSize);
+        return (int) Math.min(Integer.MAX_VALUE, Math.floor(size * maxSize));
     }
 
     @Override


### PR DESCRIPTION
This will now allow drawers to have fractional sizes instead of only whole sizes, removing the floor of the resultant size provider. So for instance, now a drawer can store exactly 2 items by having a base size of (1/32) which is 0.04 (it's actually 0.03, but we use 0.04 because we don't round and we instead floor the first 2 decimal digits, so 0.03 would actually be only one item)