### PR TITLE
[1.19] Fixed creative vending upgrades using the base stack

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/inventory/BigInventoryHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/BigInventoryHandler.java
@@ -71,7 +71,7 @@ public abstract class BigInventoryHandler implements IItemHandler, INBTSerializa
         if (slot < type.getSlots()){
             BigStack bigStack = this.storedStacks.get(slot);
             if (bigStack.getStack().isEmpty()) return ItemStack.EMPTY;
-            if (bigStack.getAmount() <= amount) {
+            if (!isCreative() && bigStack.getAmount() <= amount) {
                 ItemStack out = bigStack.getStack().copy();
                 int newAmount = bigStack.getAmount();
                 if (!simulate && !isCreative()) {

--- a/src/main/java/com/buuz135/functionalstorage/inventory/CompactingInventoryHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/CompactingInventoryHandler.java
@@ -117,7 +117,7 @@ public abstract class CompactingInventoryHandler implements IItemHandler, INBTSe
             CompactingUtil.Result bigStack = this.resultList.get(slot);
             if (bigStack.getResult().isEmpty()) return ItemStack.EMPTY;
             int stackAmount = bigStack.getNeeded() * amount;
-            if (stackAmount >= this.amount) {
+            if (!isCreative() && stackAmount >= this.amount) {
                 ItemStack out = bigStack.getResult().copy();
                 int newAmount = (int) Math.floor(this.amount / bigStack.getNeeded());
                 if (!simulate && !isCreative()) {


### PR DESCRIPTION
### Summary

Backport of the 1.20 fix for the Creative Vending Upgrade behavior when used in drawers.

### Details

In the 1.19 version, drawers equipped with a Creative Vending Upgrade incorrectly relied on the base stack for item extraction.
This caused the following issues:

- If the drawer contained 0 items, extraction was impossible.

- If it contained only 1 item, only a single item could be extracted, and so on.

### Fix

This patch aligns the 1.19 logic with the 1.20 implementation:

- The Creative Vending Upgrade now provides unlimited extraction regardless of the drawer’s base stack content.

### References

- #239 

- #255 