### PR TITLE
fix: use slot limit instead of item stack limit for extraction

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/inventory/BigInventoryHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/BigInventoryHandler.java
@@ -72,7 +72,7 @@ public abstract class BigInventoryHandler implements IItemHandler, INBTSerializa
         if (slot < type.getSlots()){
             BigStack bigStack = this.storedStacks.get(slot);
             if (bigStack.getStack().isEmpty()) return ItemStack.EMPTY;
-            amount = Math.min(amount, bigStack.getStack().getMaxStackSize());
+            amount = Math.min(amount, getSlotLimit(slot));
             if (!isCreative() && bigStack.getAmount() <= amount) {
                 ItemStack out = bigStack.getStack().copy();
                 int newAmount = bigStack.getAmount();

--- a/src/main/java/com/buuz135/functionalstorage/inventory/CompactingInventoryHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/CompactingInventoryHandler.java
@@ -122,7 +122,7 @@ public abstract class CompactingInventoryHandler implements IItemHandler, INBTSe
         if (slot < this.slots) {
             CompactingUtil.Result bigStack = this.resultList.get(slot);
             if (bigStack.getResult().isEmpty()) return ItemStack.EMPTY;
-            amount = Math.min(amount, bigStack.getResult().getMaxStackSize());
+            amount = Math.min(amount, getSlotLimit(slot));
             int stackAmount = bigStack.getNeeded() * amount;
             if (!isCreative() && stackAmount >= this.amount) {
                 ItemStack out = bigStack.getResult().copy();


### PR DESCRIPTION
Item extraction is currently capped at the item’s maximum stack size, which creates severe lag when moving large quantities especially with mods like Applied Energistics 2.

In ATM 10, a single ME IO port from Expandedae2 combined with a few Netherite‑upgraded drawers can even crash a server.

Many workflows require extracting more than an item’s max stack size, but the existing limit prevents this.

Update the logic to enforce the slot’s limit instead of the item’s max stack size, allowing larger transfers where the slot permits.