### PR TITLE
[1.20] Fix downgrades not being insertable in compacting drawers

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/block/tile/CompactingDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/CompactingDrawerTile.java
@@ -122,6 +122,11 @@ public class CompactingDrawerTile extends ItemControllableDrawerTile<CompactingD
         }
         return super.onSlotActivated(playerIn, hand, facing, hitX, hitY, hitZ, slot);
     }
+	
+	@Override
+	protected boolean canAddDowngrade() {
+		return (getStorage().getStackInSlot(2).getCount() <= 64);
+	}
 
     @Override
     public int getStorageSlotAmount() {

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/ItemControllableDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/ItemControllableDrawerTile.java
@@ -196,11 +196,9 @@ public abstract class ItemControllableDrawerTile<T extends ItemControllableDrawe
         }
                 .setInputFilter((stack, integer) -> {
                     if (stack.getItem().equals(FunctionalStorage.STORAGE_UPGRADES.get(StorageUpgradeItem.StorageTier.IRON).get())) {
-                        for (int i = 0; i < getStorage().getSlots(); i++) {
-                            if (getStorage().getStackInSlot(i).getCount() > 64) {
-                                return false;
-                            }
-                        }
+                        if (!canAddDowngrade()){
+							return false;
+						}
                     }
                     return stack.getItem() instanceof UpgradeItem && ((UpgradeItem) stack.getItem()).getType() == UpgradeItem.Type.STORAGE;
                 })
@@ -209,6 +207,15 @@ public abstract class ItemControllableDrawerTile<T extends ItemControllableDrawe
                 })
                 .setSlotLimit(1);
     }
+	
+	protected boolean canAddDowngrade() {
+		for (int i = 0; i < getStorage().getSlots(); i++) {
+			if (getStorage().getStackInSlot(i).getCount() > 64) {
+				return false;
+			}
+		}
+		return true;
+	}
 
     public boolean isEverythingEmpty() {
         for (int i = 0; i < getStorage().getSlots(); i++) {

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/SimpleCompactingDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/SimpleCompactingDrawerTile.java
@@ -122,6 +122,11 @@ public class SimpleCompactingDrawerTile extends ItemControllableDrawerTile<Simpl
         }
         return super.onSlotActivated(playerIn, hand, facing, hitX, hitY, hitZ, slot);
     }
+	
+	@Override
+	protected boolean canAddDowngrade() {
+		return (getStorage().getStackInSlot(1).getCount() <= 64);
+	}
 
     @Override
     public int getStorageSlotAmount() {


### PR DESCRIPTION
This is a partial backport of #383, fixing #371 in the 1.20 version.