### PR TITLE
[1.20] Fix storage limit for Simple Compating Drawers with a downgrade

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/inventory/CompactingInventoryHandler.java
+++ b/src/main/java/com/buuz135/functionalstorage/inventory/CompactingInventoryHandler.java
@@ -147,7 +147,7 @@ public abstract class CompactingInventoryHandler implements IItemHandler, INBTSe
         if (isCreative()) return Integer.MAX_VALUE;
         if (slot == this.slots) return Integer.MAX_VALUE;
         int total = totalAmount;
-        if (hasDowngrade()) total = 64 * 9 * 9;
+        if (hasDowngrade()) total = (slots == 2 ? 64 * 9  : 64 * 9 * 9);
         return (int) Math.min(Integer.MAX_VALUE, Math.floor(
 		        (double) (total * (long) getMultiplier()) / this.resultList.get(slot).getNeeded()));
     }
@@ -155,7 +155,7 @@ public abstract class CompactingInventoryHandler implements IItemHandler, INBTSe
     public int getSlotLimitBase(int slot) {
         if (slot == this.slots) return Integer.MAX_VALUE;
         int total = totalAmount;
-        if (hasDowngrade()) total = 64 * 9 * 9;
+        if (hasDowngrade()) total = (slots == 2 ? 64 * 9  : 64 * 9 * 9);
         return (int) Math.min(Integer.MAX_VALUE, Math.floor(total / this.resultList.get(slot).getNeeded()));
     }
 


### PR DESCRIPTION
This is a partial backport of commit [`8168bae`](https://github.com/Buuz135/FunctionalStorage/commit/8168bae5a67c02a4e50e10b2057dba823834dcb8) to 1.20, lowering the storage limit for Simple Compacting Drawers with a downgrade from 64*9 blocks to 64 blocks, which fixes the most critical part of #370. It's not perfect, as items with a 4x compression still have an incorrect storage limit (144 blocks instead of 64), but at least nothing gets voided anymore.