### PR TITLE
fix: re-checking recipe on load

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/block/tile/CompactingDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/CompactingDrawerTile.java
@@ -30,6 +30,7 @@ public class CompactingDrawerTile extends ItemControllableDrawerTile<CompactingD
 
     @Save
     public CompactingInventoryHandler handler;
+    @Save
     private boolean hasCheckedRecipes;
 
     public CompactingDrawerTile(BasicTileBlock<CompactingDrawerTile> base, BlockEntityType<CompactingDrawerTile> blockEntityType, BlockPos pos, BlockState state) {
@@ -62,18 +63,6 @@ public class CompactingDrawerTile extends ItemControllableDrawerTile<CompactingD
 
         };
         this.hasCheckedRecipes = false;
-    }
-
-    @Override
-    public void loadAdditional(CompoundTag compound, HolderLookup.Provider provider) {
-        this.hasCheckedRecipes = compound.getBoolean("hasCheckedRecipes");
-        super.loadAdditional(compound, provider);
-    }
-
-    @Override
-    protected void saveAdditional(CompoundTag compoundTag, HolderLookup.Provider provider) {
-        super.saveAdditional(compoundTag, provider);
-        compoundTag.putBoolean("hasCheckedRecipes", this.hasCheckedRecipes);
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/CompactingDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/CompactingDrawerTile.java
@@ -9,6 +9,8 @@ import com.hrznstudio.titanium.annotation.Save;
 import com.hrznstudio.titanium.block.BasicTileBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -60,6 +62,18 @@ public class CompactingDrawerTile extends ItemControllableDrawerTile<CompactingD
 
         };
         this.hasCheckedRecipes = false;
+    }
+
+    @Override
+    public void loadAdditional(CompoundTag compound, HolderLookup.Provider provider) {
+        this.hasCheckedRecipes = compound.getBoolean("hasCheckedRecipes");
+        super.loadAdditional(compound, provider);
+    }
+
+    @Override
+    protected void saveAdditional(CompoundTag compoundTag, HolderLookup.Provider provider) {
+        super.saveAdditional(compoundTag, provider);
+        compoundTag.putBoolean("hasCheckedRecipes", this.hasCheckedRecipes);
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/SimpleCompactingDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/SimpleCompactingDrawerTile.java
@@ -30,6 +30,7 @@ public class SimpleCompactingDrawerTile extends ItemControllableDrawerTile<Simpl
 
     @Save
     public CompactingInventoryHandler handler;
+    @Save
     private boolean hasCheckedRecipes;
 
     public SimpleCompactingDrawerTile(BasicTileBlock<SimpleCompactingDrawerTile> base, BlockEntityType<SimpleCompactingDrawerTile> blockEntityType, BlockPos pos, BlockState state) {
@@ -62,18 +63,6 @@ public class SimpleCompactingDrawerTile extends ItemControllableDrawerTile<Simpl
 
         };
         this.hasCheckedRecipes = false;
-    }
-
-    @Override
-    public void loadAdditional(CompoundTag compound, HolderLookup.Provider provider) {
-        this.hasCheckedRecipes = compound.getBoolean("hasCheckedRecipes");
-        super.loadAdditional(compound, provider);
-    }
-
-    @Override
-    protected void saveAdditional(CompoundTag compoundTag, HolderLookup.Provider provider) {
-        super.saveAdditional(compoundTag, provider);
-        compoundTag.putBoolean("hasCheckedRecipes", this.hasCheckedRecipes);
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/buuz135/functionalstorage/block/tile/SimpleCompactingDrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/SimpleCompactingDrawerTile.java
@@ -9,6 +9,8 @@ import com.hrznstudio.titanium.annotation.Save;
 import com.hrznstudio.titanium.block.BasicTileBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -60,6 +62,18 @@ public class SimpleCompactingDrawerTile extends ItemControllableDrawerTile<Simpl
 
         };
         this.hasCheckedRecipes = false;
+    }
+
+    @Override
+    public void loadAdditional(CompoundTag compound, HolderLookup.Provider provider) {
+        this.hasCheckedRecipes = compound.getBoolean("hasCheckedRecipes");
+        super.loadAdditional(compound, provider);
+    }
+
+    @Override
+    protected void saveAdditional(CompoundTag compoundTag, HolderLookup.Provider provider) {
+        super.saveAdditional(compoundTag, provider);
+        compoundTag.putBoolean("hasCheckedRecipes", this.hasCheckedRecipes);
     }
 
     @OnlyIn(Dist.CLIENT)


### PR DESCRIPTION
Fix re-checking already checked recipe

Example:
1. Put 43 block of coal into slot 0 (bottom right)
2. Rejoin
3. See 43 coal (not blocks)


https://github.com/user-attachments/assets/aa63137d-51b5-4059-83bc-efcc21555782

