### PR TITLE
[1.20.1] Fix removing upgrades from drawers with downgrades

### DIFF
--- a/src/main/java/com/buuz135/functionalstorage/block/tile/DrawerTile.java
+++ b/src/main/java/com/buuz135/functionalstorage/block/tile/DrawerTile.java
@@ -135,6 +135,7 @@ public class DrawerTile extends ItemControllableDrawerTile<DrawerTile> {
 
     @Override
     public int getBaseSize(int lost) {
+        if (hasDowngrade()) return 64;
         return type.getSlotAmount();
     }
 


### PR DESCRIPTION
If a drawer has an upgrade and a downgrade, the upgrade can only be removed if there are 64 items or less in the drawer.

Fixes #375.